### PR TITLE
Add CustomResourceDefinition (CRD) for Moodle Deployment

### DIFF
--- a/charts/moodle-operator/README.md
+++ b/charts/moodle-operator/README.md
@@ -1,0 +1,37 @@
+## Moodle CRD (Custom Resource Definition)
+
+This project includes a Kubernetes Custom Resource Definition (CRD) that enables the creation and management of **Moodle** instances using custom resources.
+
+### 📄 Location
+
+The CRD file is located at: moodle-plugin/charts/moodle-operator/crds
+
+
+### 🧩 What This CRD Does
+
+It defines a new resource type: `Moodle`, which lets you configure Moodle deployments declaratively in YAML.
+
+### 🧪 Example Moodle Instance
+
+```yaml
+apiVersion: moodle.adorsys.com/v1
+kind: Moodle
+metadata:
+  name: my-moodle
+spec:
+  image: bitnami/moodle:5.0.3
+  replicas: 2
+  serviceType: LoadBalancer
+  database:
+    host: postgres.default.svc.cluster.local
+    port: 5432
+    user: moodle_user
+    password: secret123
+```
+
+### Apply with ;
+```
+
+kubectl apply -f my-moodle.yaml
+
+``` 

--- a/charts/moodle-operator/crds/moodle-crd.yaml
+++ b/charts/moodle-operator/crds/moodle-crd.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: moodles.moodle.adorsys.com
+  annotations:
+    description: "Custom Resource Definition for deploying and managing Moodle instances"
+spec:
+  group: moodle.adorsys.com
+  scope: Namespaced
+  names:
+    plural: moodles
+    singular: moodle
+    kind: Moodle
+    shortNames:
+      - mdl
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: "Schema for the Moodle custom resource"
+          properties:
+            spec:
+              type: object
+              description: "Desired configuration of the Moodle instance"
+              properties:
+                image:
+                  type: string
+                  description: "Container image for the Moodle deployment"
+                replicas:
+                  type: integer
+                  minimum: 1
+                  description: "Number of Moodle pods"
+                serviceType:
+                  type: string
+                  enum: ["ClusterIP", "NodePort", "LoadBalancer"]
+                  description: "Kubernetes Service type"
+                database:
+                  type: object
+                  description: "Database connection configuration"
+                  properties:
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    user:
+                      type: string
+                    password:
+                      type: string
+            status:
+              type: object
+              description: "Current observed state of the Moodle deployment"
+              properties:
+                readyReplicas:
+                  type: integer
+                  description: "Number of ready Moodle pods"
+                phase:
+                  type: string
+                  description: "Current status phase of the Moodle instance"

--- a/packages/moodle-wasm-example/src/lib.rs
+++ b/packages/moodle-wasm-example/src/lib.rs
@@ -7,7 +7,7 @@ pub fn add(left: u64, right: u64) -> u64 {
 
 #[wasm_bindgen]
 pub fn greet(name: &str) -> String {
-    format!("Hello, {}", name)
+    format!("Hello, {name}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION


This Pull Request introduces a basic CustomResourceDefinition (CRD) to support declarative management of Moodle deployments within Kubernetes. This CRD is designed to fit the ADORSYS-GIS Moodle Operator architecture as described in project issue #13.

### Changes Included

- Created `crds/moodle-crd.yaml` defining a `Moodle` resource.
- CRD includes:
  - Metadata, status, and spec fields.
  - Descriptive properties such as image, replicas, service type, and database configuration.
- Supported service types: ClusterIP, NodePort, LoadBalancer.
- Updated `README.md` to document how to use the CRD and its schema.
