### PR TITLE
Cloud Native support (CloudNativePG)

### DIFF
--- a/charts/moodle/Chart.lock
+++ b/charts/moodle/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.5.7
-digest: sha256:7c75ee640cc38355f805228db0637f993b292bad59e81e6497e29afa58b8fc2d
-generated: "2025-07-23T16:52:03.954328568+01:00"
+- name: cloudnative-pg
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.8
+digest: sha256:07750e9ea20b1ae8eb75e53863d964aecf06ea2058b292427a27e4b75837c532
+generated: "2025-07-28T16:43:47.686407931+01:00"

--- a/charts/moodle/Chart.yaml
+++ b/charts/moodle/Chart.yaml
@@ -40,3 +40,7 @@ dependencies:
     version: 12.5.7
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
+  - name: cloudnative-pg
+    version: 1.0.8
+    repository: https://charts.bitnami.com/bitnami
+    condition: cloudnative-pg.enabled

--- a/charts/moodle/README.md
+++ b/charts/moodle/README.md
@@ -68,7 +68,7 @@ cloudnative-pg:
 
 ```bash
 helm dependency build
-helm install my-moodle . -f values.yaml
+helm install my-moodle . -f values-cnpg.yaml
 ```
 
 ---
@@ -91,11 +91,6 @@ helm template my-moodle . --values values.yaml
 
 This renders all manifests to stdout without deploying.
 
-You can verify CNPG resources like this:
-
-```bash
-helm template my-moodle . -f values.yaml | grep -C 5 "postgresql.cnpg.io"
-```
 
 ---
 
@@ -123,7 +118,7 @@ Then open:
 
 ### Alternative: Access via Multipass VM IP (NodePort)
 
-1. Upgrade with `NodePort` enabled (in `values.yaml` or `values-postgres.yaml`):
+1. Upgrade with `NodePort` enabled (in `values.yaml` ):
 
 ```bash
 helm upgrade my-moodle . -f values-postgres.yaml
@@ -164,13 +159,7 @@ helm dependency update
 
 * `values.yaml` – for use with external databases (default)
 * `values-postgres.yaml` – enables internal PostgreSQL (Bitnami)
-* You can also enable `cloudnative-pg` directly in `values.yaml`
-
-Customize with:
-
-```bash
-helm install my-moodle . -f cnpg-values.yaml
-```
+* `values-postgres.yaml`– used to enable CloudNativePG(Bitnami)  
 
 > 💡 Tip: Never hardcode production secrets in your values files. Use `--set`, `helm secrets`, or a CI/CD vault integration.
 

--- a/charts/moodle/README.md
+++ b/charts/moodle/README.md
@@ -169,7 +169,7 @@ helm dependency update
 Customize with:
 
 ```bash
-helm install my-moodle . -f my-custom-values.yaml
+helm install my-moodle . -f cnpg-values.yaml
 ```
 
 > 💡 Tip: Never hardcode production secrets in your values files. Use `--set`, `helm secrets`, or a CI/CD vault integration.

--- a/charts/moodle/values-cnpg.yaml
+++ b/charts/moodle/values-cnpg.yaml
@@ -1,0 +1,11 @@
+cloudnative-pg:
+  enabled: true
+  fullnameOverride: moodle-postgresql
+  auth:
+    username: moodle
+    password: moodlepass
+    database: moodledb
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi

--- a/charts/moodle/values.yaml
+++ b/charts/moodle/values.yaml
@@ -23,13 +23,5 @@ moodle:
     database: moodledb
 
 cloudnative-pg:
-  enabled: false
+  enabled: true
   fullnameOverride: moodle-postgresql
-  auth:
-    username: moodle
-    password: moodlepass
-    database: moodledb
-  primary:
-    persistence:
-      enabled: true
-      size: 8Gi

--- a/charts/moodle/values.yaml
+++ b/charts/moodle/values.yaml
@@ -23,7 +23,7 @@ moodle:
     database: moodledb
 
 cloudnative-pg:
-  enabled: true
+  enabled: false
   fullnameOverride: moodle-postgresql
   auth:
     username: moodle

--- a/charts/moodle/values.yaml
+++ b/charts/moodle/values.yaml
@@ -9,17 +9,27 @@ moodle:
   mariadb:
     enabled: false
 
+  postgresql:
+    enabled: false
+
   persistence:
     enabled: true
     size: 10Gi
 
-postgresql:
-  enabled: false
+  externalDatabase:
+    host: moodle-postgresql-rw
+    user: moodle
+    password: moodlepass
+    database: moodledb
+
+cloudnative-pg:
+  enabled: true
+  fullnameOverride: moodle-postgresql
   auth:
     username: moodle
-    password: moodlepassword
-    database: bitnamimoodle
+    password: moodlepass
+    database: moodledb
   primary:
     persistence:
-      enabled: false  # Disable PVC for local test clusters
-
+      enabled: true
+      size: 8Gi


### PR DESCRIPTION
This PR addresses issue #11 by adding optional CloudNativePG integration to the Moodle Helm chart. It includes the following changes:

- Adds CloudNativePG as a conditional Helm dependency
- Updates installation and testing instructions to cover CloudNativePG setup
- Expands the feature list to reflect support for both Bitnami PostgreSQL and CloudNativePG

This enables users to choose between Bitnami PostgreSQL, CloudNativePG, or external PostgreSQL services when deploying Moodle.


