### PR TITLE
feat(tos): add Terms of Service page and related language strings

### DIFF
--- a/plugins/gis-theme/adorsys_theme_v1/lang/en/theme_adorsys_theme_v1.php
+++ b/plugins/gis-theme/adorsys_theme_v1/lang/en/theme_adorsys_theme_v1.php
@@ -8,5 +8,6 @@ $string['themeheading'] = 'Adorsys Theme Settings';
 $string['themedesc'] = 'Customize the Adorsys Theme appearance.';
 $string['customcss'] = 'Custom CSS';
 $string['customcssdesc'] = 'Add custom CSS that will be applied after the main stylesheet.';
-
-
+$string['terms_of_service'] = 'Terms of Service';
+$string['toscontent']       = 'Terms of Service content';
+$string['toscontent_desc']  = 'This content will be shown on the Terms of Service page.';

--- a/plugins/gis-theme/adorsys_theme_v1/pages/tos.php
+++ b/plugins/gis-theme/adorsys_theme_v1/pages/tos.php
@@ -1,0 +1,20 @@
+<?php
+require_once(__DIR__ . '/../../../config.php');
+
+require_login();
+$context = context_system::instance();
+$PAGE->set_context($context);
+$PAGE->set_url(new moodle_url('/theme/adorsys_theme_v1/pages/tos.php'));
+$PAGE->set_pagelayout('standard'); 
+$PAGE->set_title(get_string('terms_of_service', 'theme_adorsys_theme_v1'));
+$PAGE->set_heading(get_string('terms_of_service', 'theme_adorsys_theme_v1'));
+
+$content = get_config('theme_adorsys_theme_v1', 'toscontent');
+
+$templatecontext = [
+    'heading' => get_string('terms_of_service', 'theme_adorsys_theme_v1')
+];
+echo $OUTPUT->header();
+echo $OUTPUT->render_from_template('theme_adorsys_theme_v1/tos', $templatecontext);
+
+echo $OUTPUT->footer();

--- a/plugins/gis-theme/adorsys_theme_v1/templates/tos.mustache
+++ b/plugins/gis-theme/adorsys_theme_v1/templates/tos.mustache
@@ -1,0 +1,245 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_adorsys_theme_v1/tos
+
+    This template renders the Terms of Service page for the Adorsys Theme v1.
+
+    Example usage:
+    - The page is accessible at:
+      http://moodlesite/theme/adorsys_theme_v1/pages/tos.php
+
+    Example context (json):
+    {
+      "heading": "Terms of Service"
+    }
+}}
+
+
+<div class="w-full py-10 px-4 sm:px-6 lg:px-12">
+    <div class="max-w-6xl mx-auto">
+        <div class="mb-12">
+            <h1 class="!text-6xl font-extrabold text-left ">
+                {{heading}}
+            </h1>
+        </div>
+
+        <p class="mt-8 mb-6">
+            Moodle Pty Ltd and its affiliated companies (“Moodle”, “we” or “us”), is the company at the heart
+            of the open source Moodle Project: empowering educators to improve our world. Moodle operates this
+            website ("Site"). This Site may provide you with access to a variety of web pages, documents, software,
+            services, images, graphics, audio, video, forums, discussion groups, blogs, and other content ("Content").
+        </p>
+
+        <p class="mb-6">
+            By accessing or logging into the Site, you agree to these terms. Moodle may revise these terms at any time.
+            Your continued use of the Site after any such revisions have been published constitutes your agreement
+            to the revised terms. If you do not agree to these terms, do not use the Site.
+        </p>
+
+        <p class="mb-6">
+            Personal data collected when you access and use the Site will be processed by Moodle in accordance with
+            the Moodle Privacy Notice. For more information on the types of personal data collected on the Site, how
+            Moodle handles your personal data and other related topics, please see the Moodle Privacy Notice.
+        </p>
+
+        <h2 class="text-2xl sm:text-3xl font-semibold mt-12 mb-4">1. Moodle and Third Party Content</h2>
+        <p class="mb-6">
+            When using the Site, you may be able to access or download certain Content provided by Moodle ("Moodle Content"),
+            or Content provided by third parties ("Third Party Content"). Content is governed by the licence that accompanies it.
+            By using or downloading any Content, you agree to the applicable licence. It is your responsibility to ensure you
+            have proper permission for your use of any Content. If you are unclear as to what licence applies to any Content,
+            it is recommended that you ask the author.
+        </p>
+
+        <p class="mb-6">
+            The Site, including the design, layout, look and feel, and Moodle Content, is copyrighted by Moodle and its licensors.
+            To the extent the Site, portions of the Site, or Moodle Content does not designate a licence, Moodle hereby grants you
+            a copyright licence to copy such material for your own personal or internal business purposes.
+        </p>
+
+        <h2 class="text-2xl sm:text-3xl font-semibold mt-12 mb-4">2. Your Content</h2>
+        <p class="mb-6">
+            Where applicable, you may be able to upload or otherwise provide certain Content, such as software (source code,
+            binary code, configuration files, etc.), documents, images, videos, or other material to the Site via your Account
+            ("Your Content"). Except if specifically stated otherwise, Your Content is not confidential and may be made publicly
+            available. You are responsible for keeping your own backups of Your Content. You represent that you have the right
+            to provide Your Content to Moodle and its users.
+        </p>
+
+        <p class="mb-6">
+            It's your responsibility to make clear the licence under which you are providing Your Content. You retain ownership
+            of Your Content. By posting Your Content to the Site, you hereby grant to Moodle a non-exclusive, irrevocable,
+            worldwide, royalty-free licence to use, reproduce, distribute, sublicence, adapt, modify, and publish Your Content,
+            provided this licence to Moodle does not supersede the terms of any open source licence you may explicitly apply
+            to Your Content.
+        </p>
+
+        <h2 class="text-2xl sm:text-3xl font-semibold mt-12 mb-4">3. Account</h2>
+        <p class="mb-6">
+            Where applicable, you may register for an account on the Site (an "Account"). You must provide current, complete,
+            and accurate information as required by the applicable account registration form. You or each of your authorised
+            personnel must be over the appropriate legal age to create an Account on the Site and you as Registered User warrant
+            that this requirement is met. Should Moodle be advised otherwise, it reserves the right at its sole discretion
+            to cancel/remove your Account immediately.
+        </p>
+
+        <p class="mb-6">
+            Each Account may only be accessed and used by each Registered User. In the case of employers, companies, institutions,
+            organisations or similar, the term Registered User shall include their authorised personnel. Any activity completed
+            through an Account will be deemed to have been undertaken by the Registered User. Where applicable, you may choose
+            to create an Account by authenticating via an existing account you have with a third party, in which case the third
+            party terms may also apply to such action.
+        </p>
+
+        <p class="mb-6">
+            You are responsible for the security of your Account and you agree not to share your password or access to the Site
+            with another person. Moodle is not liable for any loss or damage arising from your failure to keep your Account secure.
+            You will notify Moodle immediately if your Account information is lost, stolen, or otherwise compromised. Moodle may
+            suspend or deactivate your Account if Moodle determines that this step is needed (such as if your Account has been
+            compromised or you have violated these terms).
+        </p>
+
+        <p class="mb-6">
+            You cannot have 'Moodle' in your Account name, as this may cause confusion that you are associated with or endorsed
+            by Moodle.
+        </p>
+
+        <h2 class="text-2xl sm:text-3xl font-semibold mt-12 mb-4">4. Your Use of the Site</h2>
+        <p class="mb-6">
+            You will not use the Site in a way that violates any laws or these terms, infringes anyone's rights (including but not
+            limited to intellectual property rights), is offensive, or interferes with the Site or its features. You will follow
+            the Code of Conduct.
+        </p>
+
+        <p class="mb-6">For example, you will not use the Site or provide Content that:</p>
+        <ul class="list-disc ml-6 space-y-2 mb-6">
+            <li>Infringes, misappropriates, or violates any third party or Moodle intellectual property rights;</li>
+            <li>Is defamatory, libellous, threatening, harassing, harmful to minors, or pornographic;</li>
+            <li>Contains hateful, abusive, obscene, or violent content;</li>
+            <li>Attempts to gain unauthorised access to the Site, the server on which the Site is stored or any server, computer, or database connected to the Site;</li>
+            <li>Generates or facilitates sending unsolicited email or deploys any robot, spider, or site/search retrieval application;</li>
+            <li>Contains or distributes any viruses or programming routines intended to damage, surreptitiously intercept or expropriate any system, data, or information;</li>
+            <li>Attempts to or does mine or forge cryptocurrencies, enable illegal file sharing;</li>
+            <li>Restricts or inhibits any other user from using the Site by "hacking", "cracking", "spoofing", or defacing any portions of the Site;</li>
+            <li>Undermines our Responsible Disclosure Guidelines. If you wish to report security issues you should follow those Guidelines.</li>
+        </ul>
+
+        <p class="mb-6">
+            You may only post promotional materials relating to website or online services including post advertising or
+            commercial solicitations in compliance with our Advertising Guidelines located in section 5 or as explicitly
+            permitted by Moodle.
+        </p>
+
+        <p class="mb-6">
+            If Moodle determines that you have acted illegally, in violation of these terms, or inappropriately, Moodle may
+            terminate your Account, remove Your Content, prohibit you from using the Site, take appropriate legal actions, or
+            take other action as Moodle deems appropriate. Moodle has the right, but not the obligation, to monitor the use of
+            the Site, any Content, and any activity on the Site.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">5. Advertising Guidelines</h2>
+        <h3 class="text-xl font-medium mt-6 mb-2">Advertising commercial products and services</h3>
+        <p class="mb-6">
+            Advertising commercial products and services using Moodle’s branding or even the word “Moodle” needs careful consideration to ensure that the whole community has an equal and equitable playing field. We need to balance the support for those who financially support the Moodle Project and protect consumers from misleading conduct and confusion. Therefore, while we encourage self-disclosure of your commercial endeavours within your profile (it provides context to the discussions) we seek to restrict overuse when promoting commercial Moodle™ branded services. In short, fair use description is fine.
+        </p>
+
+        <h3 class="text-xl font-medium mt-6 mb-2">Unsolicited advertisements / spam will be deleted</h3>
+        <p class="mb-6">
+            Posting unsolicited and blatant advertisements or within forum discussions for products and services with no appropriate context are subject to deletion. Such blog entries, forum discussions, docs or other unwanted content is unacceptable use and Moodle reserves the right to take action in accordance with Section 4 (including termination of your access to the Site).
+        </p>
+
+        <h3 class="text-xl font-medium mt-6 mb-2">Official advertising that supports the Moodle Project</h3>
+        <p class="mb-6">
+            Moodle permits various types of official advertising to take place on Moodle community sites and particularly, Moodle Certified Partners and Service Providers, and Certified Integration Partners all receive certain marketing privileges, including targeted advertisement to users in the relevant Partner country locations. This privilege is afforded to Moodle Partners and Certified Integration Partners who pay royalties to participate in Moodle Partner Programs.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">6. Feedback &amp; Security Reporting</h2>
+        <p class="mb-6">
+            You may provide ideas, suggestions, proposals, or other feedback to Moodle via the Site ("Feedback"). Moodle may use such Feedback for any purpose, including incorporating the Feedback into or using the Feedback to develop and improve Moodle products and other Moodle offerings without attribution or compensation to you. You grant Moodle a perpetual and irrevocable licence to use all Feedback for any purpose. You agree to provide Feedback to Moodle only in compliance with applicable laws. You represent that you have the authority to provide the Feedback and that Feedback will not include confidential information.
+        </p>
+        <p class="mb-6">
+            At Moodle, security issues are treated very seriously. Should you believe you have uncovered a security vulnerability or data breach please follow the process outlined in our Responsible Disclosure Guidelines in Security procedures | Moodle Developer Resources.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">7. Links and References to Services</h2>
+        <p class="mb-6">
+            The Site may provide links to third party websites, products or services, which you may access or use at your own risk subject to any applicable third party terms. Moodle is not responsible for and has not endorsed such third party websites, products, or services.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">8. Disclaimer of Warranties</h2>
+        <p class="mb-6">
+            <strong>EXCEPT AS EXPRESSLY AGREED OTHERWISE IN A SIGNED AGREEMENT BETWEEN YOU AND MOODLE:</strong>
+        </p>
+        <p class="mb-6">
+            THE SITE, ANY CONTENT ON THE SITE, AND ANY SOFTWARE OR SERVICES PROVIDED ON THE SITE ARE PROVIDED "AS IS" AND MOODLE PROVIDES NO WARRANTIES EXPRESS, IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, SATISFACTORY QUALITY, NON-INFRINGEMENT OR FITNESS FOR A PARTICULAR PURPOSE. MOODLE MAKES NO WARRANTIES THAT THE SITE WILL BE SECURE OR THAT ACCESS AND USE OF THE SITE WILL BE  ERROR-FREE WITHOUT INTERRUPTIONS, CRASHES, OR DOWNTIME.
+        </p>
+        <p class="mb-6">
+            Moodle may change or discontinue part or all of the Site or any Content at any time.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">9. Limitation of Liability &amp; Indemnity</h2>
+        <p class="mb-6">
+            <strong>EXCEPT AS EXPRESSLY PROVIDED OTHERWISE IN A SIGNED AGREEMENT BETWEEN YOU AND MOODLE:</strong>
+        </p>
+        <p class="mb-6">
+            IN NO EVENT WILL MOODLE BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES WHETHER SUCH DAMAGES ARE ALLEGED AS A RESULT OF TORTIOUS CONDUCT OR BREACH OF CONTRACT OR OTHERWISE, EVEN IF MOODLE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES UNDER OR IN CONNECTION WITH THESE TERMS, INCLUDING BUT NOT LIMITED TO THE SITE, YOUR ACCESS TO OR USE OF (OR YOUR FAILURE TO GAIN ACCESS TO OR USE OF) THE SITE, ANY CONTENT PROVIDED ON THE SITE, OR ANY SERVICES PROVIDED ON THE SITE.
+        </p>
+        <p class="mb-6">
+            NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED IN THESE TERMS, THE MAXIMUM LIABILITY OF MOODLE IN AGGREGATE FOR ALL CLAIMS MADE AGAINST MOODLE IN CONTRACT, TORT, OR OTHERWISE UNDER OR IN CONNECTION WITH THESE TERMS WILL NOT EXCEED $100.
+        </p>
+        <p class="mb-6">
+            THIS STATEMENT DOES NOT AFFECT ANY LIABILITY WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+        </p>
+        <p class="mb-6">
+            You will defend and indemnify Moodle from and against any and all damages, costs, losses and expenses (including reasonable attorney fees) incurred as a result of any claim, suit or proceeding brought against Moodle in relation to Your Content, or as a result of any use or misuse of the Site by you.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">10. Trademarks</h2>
+        <p class="mb-6">
+            The trademarks, logos, trade dress and service marks displayed on the Site are the property of Moodle or other third parties. Your use of any Moodle trademark must be in accordance with the applicable Moodle Trademark Guidelines or other applicable trademark guidelines. Failure to comply with Moodle’s directions may result in Moodle taking action in accordance with Section 4 (including closure of your account).
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">11. Waiver, Severability, and Precedence</h2>
+        <p class="mb-6">
+            The failure of Moodle to exercise or enforce any right or provision of these terms does not constitute a waiver of such right or provision. If any provision of these terms is held to be unenforceable, that provision will be modified so as to be enforceable, or if such modification is not possible, will be removed and the remaining provisions will remain in full force.
+        </p>
+        <p class="mb-6">
+            Some services or Moodle Content offered via the Site may be subject to additional or separate terms. If there is a conflict between these terms and such additional or separate terms, the latter will have precedence with respect to your access and use of that service or Moodle Content. Nothing in these terms is intended to limit your rights under an open source licence.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">12. Jurisdiction</h2>
+        <p class="mb-6">
+            These terms, and any claim, controversy, or dispute arising out of or related to these terms, are governed by and construed in accordance with the laws of Western Australia without giving effect to any conflicts of laws provision.
+        </p>
+        <p class="mb-6">
+            If one or more of the provisions contained in these terms are held invalid, illegal, or unenforceable in any respect by any court of competent jurisdiction, such holding will not impair the validity, legality, or enforceability of the remaining provisions.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-12 mb-4">13. Copyright Notice and Takedown Process</h2>
+        <p class="mb-6">
+            Moodle and its affiliates respect the intellectual property of others. If you believe that content on the Site infringes your copyright or that your content on the Site was removed in error, please provide the following information to the Moodle Legal team via <a href="mailto:legal@moodle.com" class="text-blue-600 underline">legal@moodle.com</a>:
+        </p>
+        <ul class="list-disc ml-8 space-y-2 mb-6">
+            <li>A description of the copyrighted content that you claim has been infringed or removed and description of the infringing activity, including where the content is located, such as an URL.</li>
+            <li>Your full name, address, telephone number, and preferred email address.</li>
+        </ul>
+        <p class="mb-6">
+            In the first instance Moodle will investigate the matter and may refer the matter to an independent community group to adjudicate or mediate an outcome.
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
### Description

This PR introduces a new Terms of Service (ToS) page for the Moodle site using the `adorsys_theme_v1` theme.  
It includes:

- `tos.mustache` template with full Terms of Service content.
- Language strings for Terms Of Service headings and labels.


### Closes #53 #54
