### PR TITLE
ci(rust): update workflow to use checkout v5 and install rustfmt + clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run Clippy


### PR DESCRIPTION
### Summary
This PR updates the Rust CI workflow to improve reliability and fix formatting checks.

### Changes
- Bump `actions/checkout` from v4 to v5
- Configure `setup-rust-toolchain` to install `rustfmt` and `clippy`
- Ensure `cargo fmt` and `cargo clippy` run without missing component errors

### Motivation
Previously, the CI failed at the formatting check due to a missing `cargo-fmt` component.  
This update ensures the required tools are available and keeps the workflow up-to-date.
