### PR TITLE
Switch to Bitnami Legacy images.

### DIFF
--- a/charts/moodle/Chart.lock
+++ b/charts/moodle/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 12.5.7
 digest: sha256:7c75ee640cc38355f805228db0637f993b292bad59e81e6497e29afa58b8fc2d
-generated: "2025-09-17T13:29:43.818399941+01:00"
+generated: "2025-10-16T10:44:46.665179652+01:00"

--- a/charts/moodle/README.md
+++ b/charts/moodle/README.md
@@ -176,11 +176,11 @@ e.g., http://10.81.206.74:30897
 
 This chart includes the following dependencies, which are managed in `Chart.yaml`:
 
-* [bitnami/moodle](https://artifacthub.io/packages/helm/bitnamilegacy/moodle) – core Moodle deployment
-* [bitnami/postgresql](https://artifacthub.io/packages/helm/bitnamilegacy/postgresql) – optional internal PostgreSQL database
-* [bitnami/mariadb](https://artifacthub.io/packages/helm/bitnamilegacy/mariadb) – optional internal MariaDB database
-* [bitnami/common](https://artifacthub.io/packages/helm/bitnamilegacy/common) – common Bitnami utilities
-* [bitnami/cloudnative-pg](https://artifacthub.io/packages/helm/bitnamilegacy/cloudnative-pg) (conditionally enabled)
+* [bitnami/moodle](https://artifacthub.io/packages/helm/bitnami/moodle) – core Moodle deployment
+* [bitnami/postgresql](https://artifacthub.io/packages/helm/bitnami/postgresql) – optional internal PostgreSQL database
+* [bitnami/mariadb](https://artifacthub.io/packages/helm/bitnami/mariadb) – optional internal MariaDB database
+* [bitnami/common](https://artifacthub.io/packages/helm/bitnami/common) – common Bitnami utilities
+* [bitnami/cloudnative-pg](https://artifacthub.io/packages/helm/bitnami/cloudnative-pg) (conditionally enabled)
 
 **Note**: CloudNativePG resources are deployed directly by this chart when `cnpg.enabled: true`.
 

--- a/charts/moodle/README.md
+++ b/charts/moodle/README.md
@@ -61,6 +61,10 @@ helm install my-moodle . \
   -f values-postgres.yaml
 ```
 
+***Note***: add the flag ``` --set global.security.allowInsecureImages=true ```  if you trust the custom image and understand the security/performance risks.
+
+
+
 ### Option 4: CNPG Cluster + External Database
 
 Deploy Moodle with a CloudNativePG cluster managed by this chart:
@@ -172,11 +176,11 @@ e.g., http://10.81.206.74:30897
 
 This chart includes the following dependencies, which are managed in `Chart.yaml`:
 
-* [bitnami/moodle](https://artifacthub.io/packages/helm/bitnami/moodle) – core Moodle deployment
-* [bitnami/postgresql](https://artifacthub.io/packages/helm/bitnami/postgresql) – optional internal PostgreSQL database
-* [bitnami/mariadb](https://artifacthub.io/packages/helm/bitnami/mariadb) – optional internal MariaDB database
-* [bitnami/common](https://artifacthub.io/packages/helm/bitnami/common) – common Bitnami utilities
-* [bitnami/cloudnative-pg](https://artifacthub.io/packages/helm/bitnami/cloudnative-pg) (conditionally enabled)
+* [bitnami/moodle](https://artifacthub.io/packages/helm/bitnamilegacy/moodle) – core Moodle deployment
+* [bitnami/postgresql](https://artifacthub.io/packages/helm/bitnamilegacy/postgresql) – optional internal PostgreSQL database
+* [bitnami/mariadb](https://artifacthub.io/packages/helm/bitnamilegacy/mariadb) – optional internal MariaDB database
+* [bitnami/common](https://artifacthub.io/packages/helm/bitnamilegacy/common) – common Bitnami utilities
+* [bitnami/cloudnative-pg](https://artifacthub.io/packages/helm/bitnamilegacy/cloudnative-pg) (conditionally enabled)
 
 **Note**: CloudNativePG resources are deployed directly by this chart when `cnpg.enabled: true`.
 

--- a/charts/moodle/values-mariadb.yaml
+++ b/charts/moodle/values-mariadb.yaml
@@ -1,6 +1,11 @@
 moodle:
   mariadb:
     enabled: true
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/mariadb
+      tag: 12.0.2-debian-12-r0
+      pullPolicy: IfNotPresent
     auth:
       username: bn_moodle_adorsys
       password: moodlepass

--- a/charts/moodle/values-postgres.yaml
+++ b/charts/moodle/values-postgres.yaml
@@ -10,6 +10,11 @@ moodle:
     database: moodledb
 postgresql: 
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 15.2.0-debian-12-r0
+    pullPolicy: IfNotPresent
   auth:
     postgresPassword: rootPass
     username: bn_moodle_adorsys

--- a/charts/moodle/values.yaml
+++ b/charts/moodle/values.yaml
@@ -1,5 +1,10 @@
 moodle:
   debug: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/moodle
+    tag: 5.0.2-debian-12-r2
+    pullPolicy: IfNotPresent
   moodleUsername: admin
   moodlePassword: adorsys-gis
   moodleEmail: gis-udm@adorsys.com

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
   # https://github.com/bitnami/containers/tree/main/bitnami/moodle
   moodle-init:
-    image: docker.io/bitnami/moodle:5.0
+    image: docker.io/bitnamilegacy/moodle:5.0
     deploy: &moodle_deploy
       resources:
         limits:
@@ -23,21 +23,15 @@ services:
       BITNAMI_DEBUG: true
       EXTRA_LOCALES: "fr_FR.UTF-8 UTF-8, de_DE.UTF-8 UTF-8"
     entrypoint: /bin/bash
-    command: # This script was removed from https://github.com/bitnami/containers/blob/main/bitnami/moodle/5.0/debian-12/rootfs/opt/bitnami/scripts/moodle/entrypoint.sh
+    command:
       - -c
       - |
         set -ex
-
-        # Load Moodle environment
         . /opt/bitnami/scripts/moodle-env.sh
-
-        # Load libraries
         . /opt/bitnami/scripts/libbitnami.sh
         . /opt/bitnami/scripts/liblog.sh
         . /opt/bitnami/scripts/libwebserver.sh
-
         print_welcome_page
-
         info "** Starting Moodle setup **"
         . /opt/bitnami/scripts/"$(web_server_type)"/setup.sh
         . /opt/bitnami/scripts/php/setup.sh
@@ -46,7 +40,6 @@ services:
         . /opt/bitnami/scripts/moodle/setup.sh
         . /post-init.sh
         info "** Moodle setup finished! **"
-
     volumes:
       - moodle_data:/bitnami/moodle
       - moodledata_data:/bitnami/moodledata
@@ -60,9 +53,8 @@ services:
       plugin-downloader:
         condition: service_completed_successfully
 
-  # https://github.com/bitnami/containers/tree/main/bitnami/moodle
   moodle:
-    image: docker.io/bitnami/moodle:5.0
+    image: docker.io/bitnamilegacy/moodle:5.0
     deploy: *moodle_deploy
     ports:
       - "8080:8080"
@@ -71,9 +63,7 @@ services:
     volumes:
       - moodle_data:/bitnami/moodle
       - moodledata_data:/bitnami/moodledata
-      # Local source‑controlled plugins (read‑only)
       - ./plugins:/bitnami/moodle/plugins/custom/plugins:ro
-      # Plugins downloaded via Moodle UI go here (read‑write)
       - plugins_downloads:/bitnami/moodle/plugins/downloaded:ro
     depends_on:
       <<: *moodle_depends_on
@@ -81,7 +71,7 @@ services:
         condition: service_completed_successfully
 
   plugin-downloader:
-    image: alpine/git:latest # Using an image with wget/curl and unzip.
+    image: alpine/git:latest
     deploy:
       resources:
         limits:
@@ -92,9 +82,6 @@ services:
       - ./.docker/plugin-downloader/download_plugin.sh:/scripts/download_plugins.sh:ro
     environment:
       PLUGINS_DIR: "/plugin_downloads"
-      # List of plugins to download. Format: "URL,TARGET_DIR;URL,TARGET_DIR;..."
-      # Use full, direct download links to the .zip files.
-      # TARGET_DIR is the expected folder name after unzipping (e.g., 'mod_minilesson').
       PLUGINS_TO_DOWNLOAD: >
         https://moodle.org/plugins/download.php/36782/theme_seo_moodle50_2025070900.zip,theme_seo;
         https://moodle.org/plugins/download.php/36820/mod_minilesson_moodle50_2025071300.zip,mod_minilesson;
@@ -105,7 +92,7 @@ services:
       - "/scripts/download_plugins.sh"
 
   mariadb:
-    image: docker.io/bitnami/mariadb
+    image: docker.io/bitnamilegacy/mariadb:latest
     deploy:
       resources:
         limits:
@@ -122,7 +109,7 @@ services:
       - mariadb_data:/bitnami/mariadb
 
   redis:
-    image: docker.io/bitnami/redis:8.0
+    image: docker.io/bitnamilegacy/redis:8.0
     deploy:
       resources:
         limits:
@@ -161,7 +148,7 @@ services:
       retries: 3
 
   minio:
-    image: bitnami/minio:latest
+    image: docker.io/bitnamilegacy/minio:latest
     deploy:
       resources:
         limits:
@@ -181,7 +168,7 @@ services:
       retries: 5
 
   minio-object-browser:
-    image: bitnami/minio-object-browser
+    image: docker.io/bitnamilegacy/minio-object-browser:latest
     deploy:
       resources:
         limits:
@@ -197,7 +184,7 @@ services:
       - server
 
   minio-init:
-    image: bitnami/minio-client:latest
+    image: docker.io/bitnamilegacy/minio-client:latest
     deploy:
       resources:
         limits:
@@ -210,7 +197,6 @@ services:
       - -c
       - |-
         set -e;
-
         mc alias set bucketer http://minio:9000 minio-gis kwak-kwak;
         mc mb bucketer/moodle --ignore-existing
         mc anonymous set-json /tmp/policy.json bucketer/moodle
@@ -253,11 +239,6 @@ services:
       - mariadb_data:/web/mariadb_data
       - redis_data:/web/redis_data
       - minio_data:/web/minio_data
-
-#  selenium:
-#    image: "selenium/standalone-chrome"
-#    volumes:
-#      - /dev/shm:/dev/shm
 
 volumes:
   moodle_data:


### PR DESCRIPTION
 - This PR updates the Helm chart configuration to use Bitnami Legacy Docker images for improved compatibility with our existing deployment setup.