### PR TITLE
ci: update GitHub Actions to use Node.js 24 (latest LTS)

### DIFF
--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Cache Yarn dependencies
         uses: actions/cache@v4

--- a/docs/guides/06-adorsys-theme_v1.md
+++ b/docs/guides/06-adorsys-theme_v1.md
@@ -10,7 +10,7 @@ This guide will help you install the **Adorsys Theme v1** theme into your Moodle
 
 - Admin access to the Moodle UI
 
-- Node.js (>=18)
+- Node.js (>=24)
 
 - Yarn
 

--- a/plugins/gis-theme/adorsys_theme_v1/README.md
+++ b/plugins/gis-theme/adorsys_theme_v1/README.md
@@ -6,7 +6,7 @@ This repository contains the **adorsys_theme_v1** folder under `plugins/`, desig
 
 ## Prerequisites
 
-- Node.js (>=18)
+- Node.js (>=24)
 - Yarn
 - Docker & Docker Compose (see root `compose.yaml`)
 

--- a/plugins/gis-theme/adorsys_theme_v1/package.json
+++ b/plugins/gis-theme/adorsys_theme_v1/package.json
@@ -33,8 +33,8 @@
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.2"
   },
-  
+
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
The previous version (Node 18) caused build failures due to incompatibility with dependencies such as glob@13, which requires Node 22 or higher.
