### PR TITLE
CI: Publish the AI Provider and Theme Plugin

### DIFF
--- a/.github/workflows/aiprovider-release.yml
+++ b/.github/workflows/aiprovider-release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       # Parse tag
       - name: Parse plugin name & version

--- a/.github/workflows/aiprovider-release.yml
+++ b/.github/workflows/aiprovider-release.yml
@@ -1,4 +1,4 @@
-name: Provider Release
+name: AI Provider Release
 
 on:
   push:
@@ -12,37 +12,38 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # Parse tag
-      - name: Parse plugin name & version
+      - name: Parse provider name & version
         id: parse
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
 
-          # provider-{plugin_name}-v{version}
-          if [[ "$TAG" =~ ^provider-([a-zA-Z0-9_]+_v[0-9]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+          if [[ "$TAG" =~ ^provider-([a-zA-Z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
             PLUGIN="${BASH_REMATCH[1]}"
             VERSION="${BASH_REMATCH[2]}"
-            echo "plugin_name=$PLUGIN" >> $GITHUB_OUTPUT
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "plugin_path=plugins/ai/provider/$PLUGIN" >> $GITHUB_OUTPUT
+
+            {
+              echo "plugin_name=$PLUGIN"
+              echo "version=$VERSION"
+              echo "plugin_path=plugins/ai/provider/$PLUGIN"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "❌ Invalid tag format: $TAG"
             exit 1
           fi
 
-      # Validate plugin directory
-      - name: Validate plugin directory
+      - name: Validate provider directory
+        shell: bash
         run: |
-          test -d "${{ steps.parse.outputs.plugin_path }}" || {
-            echo "❌ Plugin not found: ${{ steps.parse.outputs.plugin_path }}"
+          if [[ ! -d "${{ steps.parse.outputs.plugin_path }}" ]]; then
+            echo "❌ Provider not found at ${{ steps.parse.outputs.plugin_path }}"
             exit 1
-          }
+          fi
 
-      # Package ZIP
-      - name: Package plugin
+      - name: Package provider
         id: zip
         shell: bash
         run: |
@@ -50,7 +51,7 @@ jobs:
           VERSION="${{ steps.parse.outputs.version }}"
           ZIP_PATH="${GITHUB_WORKSPACE}/${PLUGIN}-${VERSION}.zip"
 
-          cd plugins/ai/provider
+          cd "plugins/ai/provider"
 
           zip -r "$ZIP_PATH" "$PLUGIN" \
             -x "$PLUGIN/node_modules/*" \
@@ -60,14 +61,13 @@ jobs:
             -x "$PLUGIN/package-lock.json" \
             -x "$PLUGIN/**/.DS_Store"
 
-          echo "zip_path=$ZIP_PATH" >> $GITHUB_OUTPUT
+          echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
 
-      # Create GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: "${{ github.ref_name }}"
           name: "${{ steps.parse.outputs.plugin_name }} v${{ steps.parse.outputs.version }}"
-          files: ${{ steps.zip.outputs.zip_path }}
+          files: "${{ steps.zip.outputs.zip_path }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/aiprovider-release.yml
+++ b/.github/workflows/aiprovider-release.yml
@@ -3,7 +3,7 @@ name: Provider Release
 on:
   push:
     tags:
-      - 'provider-*-v*'
+      - "provider-*-v*"
 
 jobs:
   build-and-release:
@@ -40,7 +40,6 @@ jobs:
             echo "❌ Plugin not found: ${{ steps.parse.outputs.plugin_path }}"
             exit 1
           }
-
 
       # Package ZIP
       - name: Package plugin

--- a/.github/workflows/aiprovider-release.yml
+++ b/.github/workflows/aiprovider-release.yml
@@ -1,0 +1,74 @@
+name: Provider Release
+
+on:
+  push:
+    tags:
+      - 'provider-*-v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Parse tag
+      - name: Parse plugin name & version
+        id: parse
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          # provider-{plugin_name}-v{version}
+          if [[ "$TAG" =~ ^provider-([a-zA-Z0-9_]+_v[0-9]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            PLUGIN="${BASH_REMATCH[1]}"
+            VERSION="${BASH_REMATCH[2]}"
+            echo "plugin_name=$PLUGIN" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "plugin_path=plugins/ai/provider/$PLUGIN" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Invalid tag format: $TAG"
+            exit 1
+          fi
+
+      # Validate plugin directory
+      - name: Validate plugin directory
+        run: |
+          test -d "${{ steps.parse.outputs.plugin_path }}" || {
+            echo "❌ Plugin not found: ${{ steps.parse.outputs.plugin_path }}"
+            exit 1
+          }
+
+
+      # Package ZIP
+      - name: Package plugin
+        id: zip
+        shell: bash
+        run: |
+          PLUGIN="${{ steps.parse.outputs.plugin_name }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          ZIP_PATH="${GITHUB_WORKSPACE}/${PLUGIN}-${VERSION}.zip"
+
+          cd plugins/ai/provider
+
+          zip -r "$ZIP_PATH" "$PLUGIN" \
+            -x "$PLUGIN/node_modules/*" \
+            -x "$PLUGIN/.git/*" \
+            -x "$PLUGIN/.gitignore" \
+            -x "$PLUGIN/yarn.lock" \
+            -x "$PLUGIN/package-lock.json" \
+            -x "$PLUGIN/**/.DS_Store"
+
+          echo "zip_path=$ZIP_PATH" >> $GITHUB_OUTPUT
+
+      # Create GitHub Release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "${{ steps.parse.outputs.plugin_name }} v${{ steps.parse.outputs.version }}"
+          files: ${{ steps.zip.outputs.zip_path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -42,7 +42,7 @@ jobs:
       # Setup Node.js
       - uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "20"
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -1,0 +1,87 @@
+name: Theme Release
+
+# Trigger directly on tag pushes matching the theme pattern
+on:
+  push:
+    tags:
+      - 'theme-*-v*'  
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  
+ 
+    steps:
+      # Checkout code
+      - uses: actions/checkout@v5
+
+      # Parse tag for theme name & version
+      - name: Parse theme name & version
+        id: parse
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^theme-([a-zA-Z0-9_]+_v[0-9]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+            echo "theme_name=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "version=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "theme_path=plugins/gis-theme/${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid tag format: $TAG"
+            exit 1
+          fi
+
+      # Validate theme directory exists
+      - name: Validate theme directory
+        run: |
+          test -d "${{ steps.parse.outputs.theme_path }}" || {
+            echo "Theme not found at ${{ steps.parse.outputs.theme_path }}"
+            exit 1
+          }
+
+      # Setup Node.js
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      # Install dependencies
+      - name: Install dependencies
+        working-directory: ${{ steps.parse.outputs.theme_path }}
+        run: yarn install --frozen-lockfile
+
+      # Build theme
+      - name: Build theme
+        working-directory: ${{ steps.parse.outputs.theme_path }}
+        env:
+          NODE_OPTIONS: "--loader ts-node/esm"
+        run: yarn build
+
+      # Package theme as ZIP (with correct folder structure)
+      - name: Package theme
+        id: zip
+        shell: bash
+        run: |
+          THEME="${{ steps.parse.outputs.theme_name }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          ZIP_PATH="${GITHUB_WORKSPACE}/${THEME}-${VERSION}.zip"
+          
+          cd plugins/gis-theme
+          zip -r "$ZIP_PATH" "$THEME" \
+            -x "$THEME/node_modules/*" \
+            -x "$THEME/.git/*" \
+            -x "$THEME/.gitignore" \
+            -x "$THEME/yarn.lock" \
+            -x "$THEME/package-lock.json" \
+            -x "$THEME/**/.DS_Store"
+
+          echo "zip_path=$ZIP_PATH" >> $GITHUB_OUTPUT
+
+      # Create GitHub Release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "${{ steps.parse.outputs.theme_name }}"
+          files: ${{ steps.zip.outputs.zip_path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       # Checkout code
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       # Parse tag for theme name & version
       - name: Parse theme name & version
@@ -40,7 +40,7 @@ jobs:
           }
 
       # Setup Node.js
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: "24"
 

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -4,14 +4,14 @@ name: Theme Release
 on:
   push:
     tags:
-      - 'theme-*-v*'  
+      - "theme-*-v*"
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  
- 
+      contents: write
+
     steps:
       # Checkout code
       - uses: actions/checkout@v5
@@ -64,7 +64,7 @@ jobs:
           THEME="${{ steps.parse.outputs.theme_name }}"
           VERSION="${{ steps.parse.outputs.version }}"
           ZIP_PATH="${GITHUB_WORKSPACE}/${THEME}-${VERSION}.zip"
-          
+
           cd plugins/gis-theme
           zip -r "$ZIP_PATH" "$THEME" \
             -x "$THEME/node_modules/*" \

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -67,15 +67,11 @@ jobs:
           VERSION="${{ steps.parse.outputs.version }}"
           ZIP_PATH="${GITHUB_WORKSPACE}/${THEME}-${VERSION}.zip"
 
-          cd "plugins/gis-theme"
+          BUILD_PATH="outputs/plugins/gis-theme/${THEME}"
 
-          zip -r "$ZIP_PATH" "$THEME" \
-            -x "$THEME/node_modules/*" \
-            -x "$THEME/.git/*" \
-            -x "$THEME/.gitignore" \
-            -x "$THEME/yarn.lock" \
-            -x "$THEME/package-lock.json" \
-            -x "$THEME/**/.DS_Store"
+          cd "$BUILD_PATH"
+
+          zip -r "$ZIP_PATH" .
 
           echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/theme-release.yml
+++ b/.github/workflows/theme-release.yml
@@ -1,6 +1,5 @@
 name: Theme Release
 
-# Trigger directly on tag pushes matching the theme pattern
 on:
   push:
     tags:
@@ -13,50 +12,53 @@ jobs:
       contents: write
 
     steps:
-      # Checkout code
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # Parse tag for theme name & version
       - name: Parse theme name & version
         id: parse
         shell: bash
         run: |
           TAG="${GITHUB_REF_NAME}"
+
           if [[ "$TAG" =~ ^theme-([a-zA-Z0-9_]+_v[0-9]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
-            echo "theme_name=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
-            echo "version=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-            echo "theme_path=plugins/gis-theme/${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            {
+              echo "theme_name=${BASH_REMATCH[1]}"
+              echo "version=${BASH_REMATCH[2]}"
+              echo "theme_path=plugins/gis-theme/${BASH_REMATCH[1]}"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "Invalid tag format: $TAG"
+            echo "❌ Invalid tag format: $TAG"
             exit 1
           fi
 
-      # Validate theme directory exists
       - name: Validate theme directory
+        shell: bash
         run: |
-          test -d "${{ steps.parse.outputs.theme_path }}" || {
-            echo "Theme not found at ${{ steps.parse.outputs.theme_path }}"
+          if [[ ! -d "${{ steps.parse.outputs.theme_path }}" ]]; then
+            echo "❌ Theme not found at ${{ steps.parse.outputs.theme_path }}"
             exit 1
-          }
+          fi
 
-      # Setup Node.js
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
+          cache: yarn
+          cache-dependency-path: "${{ steps.parse.outputs.theme_path }}/yarn.lock"
 
-      # Install dependencies
       - name: Install dependencies
-        working-directory: ${{ steps.parse.outputs.theme_path }}
+        working-directory: "${{ steps.parse.outputs.theme_path }}"
+        shell: bash
         run: yarn install --frozen-lockfile
 
-      # Build theme
       - name: Build theme
-        working-directory: ${{ steps.parse.outputs.theme_path }}
+        working-directory: "${{ steps.parse.outputs.theme_path }}"
+        shell: bash
         env:
           NODE_OPTIONS: "--loader ts-node/esm"
         run: yarn build
 
-      # Package theme as ZIP (with correct folder structure)
       - name: Package theme
         id: zip
         shell: bash
@@ -65,7 +67,8 @@ jobs:
           VERSION="${{ steps.parse.outputs.version }}"
           ZIP_PATH="${GITHUB_WORKSPACE}/${THEME}-${VERSION}.zip"
 
-          cd plugins/gis-theme
+          cd "plugins/gis-theme"
+
           zip -r "$ZIP_PATH" "$THEME" \
             -x "$THEME/node_modules/*" \
             -x "$THEME/.git/*" \
@@ -74,14 +77,13 @@ jobs:
             -x "$THEME/package-lock.json" \
             -x "$THEME/**/.DS_Store"
 
-          echo "zip_path=$ZIP_PATH" >> $GITHUB_OUTPUT
+          echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
 
-      # Create GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: "${{ github.ref_name }}"
           name: "${{ steps.parse.outputs.theme_name }}"
-          files: ${{ steps.zip.outputs.zip_path }}
+          files: "${{ steps.zip.outputs.zip_path }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@ frontend-example
 
 # Ignore generated theme build
 outputs/
-
+event.json
+event-plugin.json
+bin
+.actrc

--- a/docs/guides/07-plugin-release.md
+++ b/docs/guides/07-plugin-release.md
@@ -5,69 +5,89 @@ This guide explains how to trigger Theme Releases and Provider Plugin Releases u
 Both release pipelines run automatically when a correctly formatted tag is pushed.
 
 ## 📌 1. Tag Naming Conventions
+
 ### Themes
+
 ```
 theme-{theme_name}-v{version}
 ```
 
 **Example:**
+
 ```
 theme-adorsys_theme_v1-v1.2.3
 ```
+
 ### Providers
+
 ```
 provider-{provider_name}-v{version}
 ```
 
 **Example:**
+
 ```
 provider-openai_compatible_v1-v1.0.0
 ```
+
 ## 📌 2. Required Folder Structure
 
 ### Themes:
+
 ```
 plugins/gis-theme/{theme_name}
 ```
 
 **Example:**
+
 ```
 plugins/gis-theme/adorsys_theme_v1
 ```
+
 ### Providers:
+
 ```
 plugins/ai/provider/{provider_name}
 ```
 
 **Example:**
+
 ```
 plugins/ai/provider/openaicompatible
 ```
+
 ## 🚀 3. How to Trigger a Release (Local Git)
 
 **1️⃣ Push your latest code**
+
 ```
 git push
 ```
+
 **2️⃣ Create a tag**
 
 Theme example:
+
 ```
 git tag theme-adorsys_theme_v1-v1.2.3
 ```
 
 Provider example:
+
 ```
 git tag provider-openaicompatible-v1.0.0
 ```
+
 Creating the tag opens your editor, where you can add an optional description.
 
 **3️⃣ Push the tag**
+
 ```
 git push origin <tag-name>
 ```
 
 **Examples:**
+
 ```
 git push origin theme-adorsys_theme_v1-v1.2.3
 git push origin provider-openaicompatible-v1.0.0

--- a/docs/guides/07-plugin-release.md
+++ b/docs/guides/07-plugin-release.md
@@ -1,0 +1,82 @@
+# 🚀 Release Guide for Themes & Provider Plugins
+
+This guide explains how to trigger Theme Releases and Provider Plugin Releases using Git tags.
+
+Both release pipelines run automatically when a correctly formatted tag is pushed.
+
+## 📌 1. Tag Naming Conventions
+### Themes
+```
+theme-{theme_name}-v{version}
+```
+
+**Example:**
+```
+theme-adorsys_theme_v1-v1.2.3
+```
+### Providers
+```
+provider-{provider_name}-v{version}
+```
+
+**Example:**
+```
+provider-openai_compatible_v1-v1.0.0
+```
+## 📌 2. Required Folder Structure
+
+### Themes:
+```
+plugins/gis-theme/{theme_name}
+```
+
+**Example:**
+```
+plugins/gis-theme/adorsys_theme_v1
+```
+### Providers:
+```
+plugins/ai/provider/{provider_name}
+```
+
+**Example:**
+```
+plugins/ai/provider/openaicompatible
+```
+## 🚀 3. How to Trigger a Release (Local Git)
+
+**1️⃣ Push your latest code**
+```
+git push
+```
+**2️⃣ Create a tag**
+
+Theme example:
+```
+git tag theme-adorsys_theme_v1-v1.2.3
+```
+
+Provider example:
+```
+git tag provider-openaicompatible-v1.0.0
+```
+Creating the tag opens your editor, where you can add an optional description.
+
+**3️⃣ Push the tag**
+```
+git push origin <tag-name>
+```
+
+**Examples:**
+```
+git push origin theme-adorsys_theme_v1-v1.2.3
+git push origin provider-openaicompatible-v1.0.0
+```
+
+Once the tag is pushed, GitHub Actions will automatically:
+
+Build the theme/provider
+
+Package it as a .zip
+
+Create a GitHub Release with the artifact


### PR DESCRIPTION
This PR introduces automated release workflows for themes and AI provider plugins using GitHub Actions. Pushing a tag in the format` theme-{name}-v{version}` or `provider-{name}-v{version}` now automatically **builds**, **packages**, and **creates a GitHub Release** with the plugin ZIP artifact.

New documentation in `docs/guides/07-plugin-release.md`,  explains the tagging convention, required folder structure, and provides a step-by-step guide to trigger a release. 