### PR TITLE
fix(ai): correct config precedence and port MDL-85352 image generation updates

### DIFF
--- a/plugins/ai/provider/openaicompatible/README.md
+++ b/plugins/ai/provider/openaicompatible/README.md
@@ -54,19 +54,18 @@ Navigate to **Site Administration → AI → AI Providers → OpenAI Compatible*
 
 ### Global Settings
 
-These settings serve as the defaults for all actions unless overridden.
+These settings configure the core authentication and routing for the provider.
 
 -   **API Endpoint**: The base URL of your AI service (e.g., `https://api.openai.com/v1`).
--   **Model**: The default model identifier (e.g., `gpt-4o`, `llama3`).
--   **API Key**: Your service authentication key.
--   **OpenAI organization ID**: (Optional) For services that require an organization context.
+-   **OpenAI compatible API Key**: Your service authentication key.
+-   **OpenAI compatible organization ID**: (Optional) For services that require an organization context.
 
 ### Action-Specific Settings
 
-You can customize behavior for each action type (e.g., use a different model for Summarization).
+Models must be explicitly configured at the action level. You can customize behavior for each action type.
 
 1.  Go to the **Actions** configuration for the provider.
-2.  Override the **Model** or **API Endpoint** if needed.
+2.  Set the **Model** for the action, or override the **API Endpoint** if needed.
 3.  **System Instruction**: Customize the system prompt sent to the LLM (for Text Generation, Summarization, etc.).
 4.  **Extra Parameters**: Pass custom JSON parameters to the model (e.g., `{"temperature": 0.7}`).
 

--- a/plugins/ai/provider/openaicompatible/README.md
+++ b/plugins/ai/provider/openaicompatible/README.md
@@ -5,7 +5,7 @@ This plugin enables Moodle to connect with any AI service that adheres to the Op
 ## Features
 
 - **Universal Compatibility**: Connect to any custom API endpoint (e.g., `https://my-ai.com/api/v1`).
-- **Flexible Model Strategy**: Supports standard models (`gpt-4o`, `dall-e-3`) or any **Custom Model** name required by your backend.
+- **Flexible Model Strategy**: Supports standard models (`gpt-4o`, `gpt-image-1`) or any **Custom Model** name required by your backend.
 - **Full Action Support**: Implements all core Moodle AI actions:
   - **Generate Text**
   - **Generate Image**

--- a/plugins/ai/provider/openaicompatible/UPGRADING.md
+++ b/plugins/ai/provider/openaicompatible/UPGRADING.md
@@ -1,0 +1,18 @@
+# aiprovider_openaicompatible Upgrade notes
+
+## V next
+
+### Added
+
+- A new `gpt4o` model class has been added to support text generation.
+- A new `gptimage1` model class has been added to support image generation via `gpt-image-1`.
+  This model uses `output_format=png` instead of `response_format`, and maps Moodle quality values to the values expected by the API: 'standard' maps to 'medium' and 'hd' maps to 'high'. Image data is returned directly via `b64_json`.
+
+### Changed
+
+- Configuration precedence has been inverted: Action-level model and endpoint settings now correctly override the global provider-level defaults.
+
+
+### Removed
+
+- The `dalle3` model class has been removed in favor of the new `gpt-image-1` strategy.

--- a/plugins/ai/provider/openaicompatible/UPGRADING.md
+++ b/plugins/ai/provider/openaicompatible/UPGRADING.md
@@ -16,3 +16,4 @@
 ### Removed
 
 - The `dalle3` model class has been removed in favor of the new `gpt-image-1` strategy.
+- The global provider-level `model` setting has been removed entirely. All models must now be configured at the action level.

--- a/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
+++ b/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
@@ -76,21 +76,34 @@ abstract class abstract_processor extends process_base {
      */
     protected function get_model_settings(): array {
         $settings = $this->provider->actionconfig[$this->action::class]['settings'];
-        if (!empty($settings['modelextraparams'])) {
-            // Custom model settings.
+        $model = $this->get_model();
+        
+        // Extract extra params from the form structure if present.
+        if (!empty($settings['modelsettings'][$model]['modelextraparams'])) {
+            $params = json_decode($settings['modelsettings'][$model]['modelextraparams'], true);
+            if (is_array($params)) {
+                foreach ($params as $key => $param) {
+                    $settings[$key] = $param;
+                }
+            }
+        } else if (!empty($settings['modelextraparams'])) {
+            // Fallback for older data format.
             $params = json_decode($settings['modelextraparams'], true);
-            foreach ($params as $key => $param) {
-                $settings[$key] = $param;
+            if (is_array($params)) {
+                foreach ($params as $key => $param) {
+                    $settings[$key] = $param;
+                }
             }
         }
 
-        // Unset unnecessary settings.
+        // Unset unnecessary settings so they don't get sent to the API.
         unset(
             $settings['model'],
             $settings['endpoint'],
             $settings['systeminstruction'],
             $settings['providerid'],
             $settings['modelextraparams'],
+            $settings['modelsettings'],
         );
         return $settings;
     }
@@ -135,29 +148,10 @@ abstract class abstract_processor extends process_base {
 
         $client = \core\di::get(http_client::class);
         
-        // Construct the full absolute URI manually to avoid Guzzle base_uri merging ambiguities.
-        $endpoint = $this->get_endpoint();
-        $endpointstr = (string) $endpoint;
-        // Ensure trailing slash for base.
-        if (substr($endpointstr, -1) !== '/') {
-            $endpointstr .= '/';
-        }
-        
-        $requestpath = $request->getUri()->getPath();
-        // If the endpoint already contains the request path (e.g. user entered full URL), don't append it again.
-        // We check if the end of the endpoint matches the request path (ignoring the trailing slash we just added).
-        $endpointrtrim = rtrim($endpointstr, '/');
-        if (str_ends_with($endpointrtrim, $requestpath)) {
-             $newuri = new Uri($endpointstr);
-        } else {
-             $newuri = new Uri($endpointstr . $request->getUri());
-        }
-        $request = $request->withUri($newuri);
-
         try {
             // Call the external AI service.
-            // We pass an empty base_uri because we've already set the full URI on the request.
             $response = $client->send($request, [
+                'base_uri' => $this->get_endpoint(),
                 RequestOptions::HTTP_ERRORS => false,
             ]);
         } catch (RequestException $e) {

--- a/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
+++ b/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
@@ -40,12 +40,12 @@ abstract class abstract_processor extends process_base {
      */
     protected function get_endpoint(): UriInterface {
         $endpoint = null;
-        if (method_exists($this->provider, 'get_api_endpoint')) {
-            $endpoint = $this->provider->get_api_endpoint();
+        if (!empty($this->provider->actionconfig[$this->action::class]['settings']['endpoint'])) {
+            $endpoint = $this->provider->actionconfig[$this->action::class]['settings']['endpoint'];
         }
-        
-        if (empty($endpoint)) {
-             $endpoint = $this->provider->actionconfig[$this->action::class]['settings']['endpoint'];
+
+        if (empty($endpoint) && method_exists($this->provider, 'get_api_endpoint')) {
+            $endpoint = $this->provider->get_api_endpoint();
         }
         
         return new Uri($endpoint);
@@ -58,12 +58,12 @@ abstract class abstract_processor extends process_base {
      */
     protected function get_model(): string {
         $model = null;
-        if (method_exists($this->provider, 'get_api_model')) {
-            $model = $this->provider->get_api_model();
-        }
-        
-        if (empty($model)) {
+        if (!empty($this->provider->actionconfig[$this->action::class]['settings']['model'])) {
             $model = $this->provider->actionconfig[$this->action::class]['settings']['model'];
+        }
+
+        if (empty($model) && method_exists($this->provider, 'get_api_model')) {
+            $model = $this->provider->get_api_model();
         }
         
         return $model;

--- a/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
+++ b/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
@@ -66,10 +66,6 @@ abstract class abstract_processor extends process_base {
         if (!empty($this->provider->actionconfig[$this->action::class]['settings']['model'])) {
             $model = $this->provider->actionconfig[$this->action::class]['settings']['model'];
         }
-
-        if (empty($model) && method_exists($this->provider, 'get_api_model')) {
-            $model = $this->provider->get_api_model();
-        }
         
         return $model;
     }

--- a/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
+++ b/plugins/ai/provider/openaicompatible/classes/abstract_processor.php
@@ -45,7 +45,12 @@ abstract class abstract_processor extends process_base {
         }
 
         if (empty($endpoint) && method_exists($this->provider, 'get_api_endpoint')) {
-            $endpoint = $this->provider->get_api_endpoint();
+            $endpoint = rtrim($this->provider->get_api_endpoint(), '/');
+            if ($this->action instanceof \core_ai\aiactions\generate_image) {
+                $endpoint .= '/images/generations';
+            } else {
+                $endpoint .= '/chat/completions';
+            }
         }
         
         return new Uri($endpoint);

--- a/plugins/ai/provider/openaicompatible/classes/aimodel/dalle3.php
+++ b/plugins/ai/provider/openaicompatible/classes/aimodel/dalle3.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openaicompatible\aimodel;
+
+use core_ai\aimodel\base;
+
+/**
+ * DALL-E 3 OpenAI model class.
+ *
+ * @package    aiprovider_openaicompatible
+ * @copyright  2025   Adorsys GIS <gis-udm@adorsys.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class dalle3 extends base implements openai_base, openai_image_base {
+
+    #[\Override]
+    public function get_model_name(): string {
+        return 'dall-e-3';
+    }
+
+    #[\Override]
+    public function get_model_display_name(): string {
+        return 'DALL-E 3';
+    }
+
+    #[\Override]
+    public function model_type(): array {
+        return [self::MODEL_TYPE_IMAGE];
+    }
+
+    #[\Override]
+    public function calculate_quality(string $quality): string {
+        if ($quality === 'standard') {
+            return 'standard';
+        } else if ($quality === 'hd') {
+            return 'hd';
+        }
+        return 'standard';
+    }
+
+    #[\Override]
+    public function calculate_size(string $aspectratio): string {
+        if ($aspectratio === 'portrait') {
+            return '1024x1792';
+        } else if ($aspectratio === 'landscape') {
+            return '1792x1024';
+        }
+
+        // Return a square image for all other aspect ratios.
+        return '1024x1024';
+    }
+
+    #[\Override]
+    public function response_format(): ?string {
+        return 'b64_json';
+    }
+
+    #[\Override]
+    public function get_output_format(): ?string {
+        // DALL-E 3 does not accept output_format
+        return null;
+    }
+}

--- a/plugins/ai/provider/openaicompatible/classes/aimodel/gpt4o.php
+++ b/plugins/ai/provider/openaicompatible/classes/aimodel/gpt4o.php
@@ -1,0 +1,115 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openaicompatible\aimodel;
+
+use core_ai\aimodel\base;
+use MoodleQuickForm;
+
+/**
+ * GPT-4o AI model.
+ *
+ * @package    aiprovider_openaicompatible
+ * @copyright  2025 Adorsys GIS <gis-udm@adorsys.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class gpt4o extends base implements openai_base {
+
+    #[\Override]
+    public function get_model_name(): string {
+        return 'gpt-4o';
+    }
+
+    #[\Override]
+    public function get_model_display_name(): string {
+        return 'GPT-4o';
+    }
+
+    #[\Override]
+    public function get_model_settings(): array {
+        return [
+            'top_p' => [
+                'elementtype' => 'text',
+                'label' => [
+                    'identifier' => 'settings_top_p',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+                'type' => PARAM_FLOAT,
+                'help' => [
+                    'identifier' => 'settings_top_p',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+            ],
+            'max_completion_tokens' => [
+                'elementtype' => 'text',
+                'label' => [
+                    'identifier' => 'settings_max_completion_tokens',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+                'type' => PARAM_INT,
+                'help' => [
+                    'identifier' => 'settings_max_completion_tokens',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+            ],
+            'frequency_penalty' => [
+                'elementtype' => 'text',
+                'label' => [
+                    'identifier' => 'settings_frequency_penalty',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+                'type' => PARAM_RAW, // Float from -2.0 to 2.0.
+                'help' => [
+                    'identifier' => 'settings_frequency_penalty',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+            ],
+            'presence_penalty' => [
+                'elementtype' => 'text',
+                'label' => [
+                    'identifier' => 'settings_presence_penalty',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+                'type' => PARAM_RAW, // Float from -2.0 to 2.0.
+                'help' => [
+                    'identifier' => 'settings_presence_penalty',
+                    'component' => 'aiprovider_openaicompatible',
+                ],
+            ],
+        ];
+    }
+
+    #[\Override]
+    public function add_model_settings(MoodleQuickForm $mform): void {
+        $settings = $this->get_model_settings();
+        foreach ($settings as $key => $setting) {
+            $mform->addElement(
+                $setting['elementtype'],
+                $key,
+                get_string($setting['label']['identifier'], $setting['label']['component']),
+            );
+            $mform->setType($key, $setting['type']);
+            if (isset($setting['help'])) {
+                $mform->addHelpButton($key, $setting['help']['identifier'], $setting['help']['component']);
+            }
+        }
+    }
+
+    #[\Override]
+    public function model_type(): array {
+        return [self::MODEL_TYPE_TEXT];
+    }
+}

--- a/plugins/ai/provider/openaicompatible/classes/aimodel/gptimage1.php
+++ b/plugins/ai/provider/openaicompatible/classes/aimodel/gptimage1.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openaicompatible\aimodel;
+
+use core_ai\aimodel\base;
+
+/**
+ * GPT Image 1 AI model.
+ *
+ * @package    aiprovider_openaicompatible
+ * @copyright  2025   Adorsys GIS <gis-udm@adorsys.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class gptimage1 extends base implements openai_base, openai_image_base {
+    #[\Override]
+    public function get_model_display_name(): string {
+        return 'GPT Image 1';
+    }
+
+    #[\Override]
+    public function get_model_name(): string {
+        return 'gpt-image-1';
+    }
+
+    #[\Override]
+    public function model_type(): array {
+        return [self::MODEL_TYPE_IMAGE];
+    }
+
+    #[\Override]
+    public function response_format(): ?string {
+        // gpt-image-1 does not accept response_format as an API parameter.
+        return null;
+    }
+
+    #[\Override]
+    public function get_output_format(): ?string {
+        return 'png';
+    }
+
+    #[\Override]
+    public function calculate_size(string $ratio): string {
+        if ($ratio === 'square') {
+            $size = '1024x1024';
+        } else if ($ratio === 'landscape') {
+            $size = '1536x1024';
+        } else if ($ratio === 'portrait') {
+            $size = '1024x1536';
+        } else {
+            throw new \coding_exception('Invalid aspect ratio: ' . $ratio);
+        }
+        return $size;
+    }
+
+    #[\Override]
+    public function calculate_quality(string $quality): string {
+        if ($quality === 'standard') {
+            $processedquality = 'medium';
+        } else if ($quality === 'hd') {
+            $processedquality = 'high';
+        } else {
+            throw new \coding_exception('Invalid quality: ' . $quality);
+        }
+        return $processedquality;
+    }
+}

--- a/plugins/ai/provider/openaicompatible/classes/aimodel/openai_image_base.php
+++ b/plugins/ai/provider/openaicompatible/classes/aimodel/openai_image_base.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace aiprovider_openaicompatible\aimodel;
+
+/**
+ * OpenAI-compatible base AI image generation model interface.
+ *
+ * @package    aiprovider_openaicompatible
+ * @copyright  2025   Adorsys GIS <gis-udm@adorsys.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+interface openai_image_base {
+    /**
+     * Get response format.
+     *
+     * Return null if the model does not support the response_format API parameter.
+     *
+     * @return string|null response format, or null to omit the parameter from the request.
+     */
+    public function response_format(): ?string;
+
+    /**
+     * Get output image format (file extension) to send as the output_format request parameter.
+     *
+     * Return null if the model does not support the output_format API parameter.
+     *
+     * @return string|null Output format (e.g. 'png'), or null to omit the parameter from the request.
+     */
+    public function get_output_format(): ?string;
+
+    /**
+     * Convert the given aspect ratio to an image size compatible with the model's API.
+     *
+     * @param string $ratio The aspect ratio (square, landscape, portrait).
+     * @return string The size string for the API request.
+     */
+    public function calculate_size(string $ratio): string;
+
+    /**
+     * Convert the given quality setting to the value expected by the model's API.
+     *
+     * @param string $quality The quality setting (standard, hd).
+     * @return string The quality value for the API request.
+     */
+    public function calculate_quality(string $quality): string;
+}

--- a/plugins/ai/provider/openaicompatible/classes/form/action_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_form.php
@@ -172,12 +172,15 @@ class action_form extends action_settings_form {
         $actionname = $this->actionname;
 
         // Determine which model to use as the default.
+        // If a model is saved and it's not in the named list (or has extra params), use 'custom' mode.
+        // If no model is saved, default to 'custom' so the admin must explicitly name one.
+        // This mirrors the upstream aiprovider_openai behaviour after MDL-85352.
         if (!empty($this->actionconfig['model']) &&
                 (!array_key_exists($this->actionconfig['model'], $this->get_model_list($modeltype)) ||
                 !empty($this->actionconfig['modelextraparams']))) {
             $defaultmodel = 'custom';
         } else if (empty($this->actionconfig['model'])) {
-            $defaultmodel = ($actionname === 'generate_image') ? 'dall-e-3' : 'gpt-4o';
+            $defaultmodel = 'custom';
         } else {
             $defaultmodel = $this->actionconfig['model'];
         }

--- a/plugins/ai/provider/openaicompatible/classes/form/action_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_form.php
@@ -174,13 +174,12 @@ class action_form extends action_settings_form {
         // Determine which model to use as the default.
         // If a model is saved and it's not in the named list (or has extra params), use 'custom' mode.
         // If no model is saved, default to 'custom' so the admin must explicitly name one.
-        // This mirrors the upstream aiprovider_openai behaviour after MDL-85352.
         if (!empty($this->actionconfig['model']) &&
                 (!array_key_exists($this->actionconfig['model'], $this->get_model_list($modeltype)) ||
                 !empty($this->actionconfig['modelextraparams']))) {
             $defaultmodel = 'custom';
         } else if (empty($this->actionconfig['model'])) {
-            $defaultmodel = 'custom';
+            $defaultmodel = ($actionname === 'generate_image') ? 'gpt-image-1' : 'gpt-4o';
         } else {
             $defaultmodel = $this->actionconfig['model'];
         }

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
@@ -41,8 +41,7 @@ class action_generate_image_form extends action_form {
             'maxlength="255" size="30"',
         );
         $mform->setType('endpoint', PARAM_URL);
-        $mform->addRule('endpoint', null, 'required', null, 'client');
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? 'https://api.openai.com/v1/');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
 
         if ($this->returnurl) {
             $mform->addElement('hidden', 'returnurl', $this->returnurl);

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
@@ -40,8 +40,22 @@ class action_generate_image_form extends action_form {
             get_string("action:{$this->actionname}:endpoint", 'aiprovider_openaicompatible'),
             'maxlength="255" size="30"',
         );
+        // Generate a dynamic endpoint based on the provider's API endpoint.
+        global $DB;
+        $providerendpoint = 'https://api.openai.com/v1'; // Default fallback
+        if (!empty($this->providerid)) {
+            if ($provider = $DB->get_record('ai_providers', ['id' => $this->providerid])) {
+                $config = json_decode($provider->config);
+                if (!empty($config->apiendpoint)) {
+                    $providerendpoint = rtrim($config->apiendpoint, '/');
+                }
+            }
+        }
+        
         $mform->setType('endpoint', PARAM_URL);
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? $providerendpoint . '/images/generations');
+
+
 
         if ($this->returnurl) {
             $mform->addElement('hidden', 'returnurl', $this->returnurl);

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
@@ -43,9 +43,6 @@ class action_generate_image_form extends action_form {
         $mform->setType('endpoint', PARAM_URL);
         $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
 
-
-
-
         if ($this->returnurl) {
             $mform->addElement('hidden', 'returnurl', $this->returnurl);
             $mform->setType('returnurl', PARAM_LOCALURL);

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_image_form.php
@@ -40,20 +40,9 @@ class action_generate_image_form extends action_form {
             get_string("action:{$this->actionname}:endpoint", 'aiprovider_openaicompatible'),
             'maxlength="255" size="30"',
         );
-        // Generate a dynamic endpoint based on the provider's API endpoint.
-        global $DB;
-        $providerendpoint = 'https://api.openai.com/v1'; // Default fallback
-        if (!empty($this->providerid)) {
-            if ($provider = $DB->get_record('ai_providers', ['id' => $this->providerid])) {
-                $config = json_decode($provider->config);
-                if (!empty($config->apiendpoint)) {
-                    $providerendpoint = rtrim($config->apiendpoint, '/');
-                }
-            }
-        }
-        
         $mform->setType('endpoint', PARAM_URL);
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? $providerendpoint . '/images/generations');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
+
 
 
 

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
@@ -41,8 +41,7 @@ class action_generate_text_form extends action_form {
             'maxlength="255" size="30"',
         );
         $mform->setType('endpoint', PARAM_URL);
-        $mform->addRule('endpoint', null, 'required', null, 'client');
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? 'https://api.openai.com/v1/');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
 
         // System Instructions.
         $mform->addElement(

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
@@ -43,9 +43,6 @@ class action_generate_text_form extends action_form {
         $mform->setType('endpoint', PARAM_URL);
         $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
 
-
-
-
         // System Instructions.
         $mform->addElement(
             'textarea',

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
@@ -40,20 +40,9 @@ class action_generate_text_form extends action_form {
             get_string("action:{$this->actionname}:endpoint", 'aiprovider_openaicompatible'),
             'maxlength="255" size="30"',
         );
-        // Generate a dynamic endpoint based on the provider's API endpoint.
-        global $DB;
-        $providerendpoint = 'https://api.openai.com/v1'; // Default fallback
-        if (!empty($this->providerid)) {
-            if ($provider = $DB->get_record('ai_providers', ['id' => $this->providerid])) {
-                $config = json_decode($provider->config);
-                if (!empty($config->apiendpoint)) {
-                    $providerendpoint = rtrim($config->apiendpoint, '/');
-                }
-            }
-        }
-        
         $mform->setType('endpoint', PARAM_URL);
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? $providerendpoint . '/chat/completions');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
+
 
 
 

--- a/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
+++ b/plugins/ai/provider/openaicompatible/classes/form/action_generate_text_form.php
@@ -40,8 +40,22 @@ class action_generate_text_form extends action_form {
             get_string("action:{$this->actionname}:endpoint", 'aiprovider_openaicompatible'),
             'maxlength="255" size="30"',
         );
+        // Generate a dynamic endpoint based on the provider's API endpoint.
+        global $DB;
+        $providerendpoint = 'https://api.openai.com/v1'; // Default fallback
+        if (!empty($this->providerid)) {
+            if ($provider = $DB->get_record('ai_providers', ['id' => $this->providerid])) {
+                $config = json_decode($provider->config);
+                if (!empty($config->apiendpoint)) {
+                    $providerendpoint = rtrim($config->apiendpoint, '/');
+                }
+            }
+        }
+        
         $mform->setType('endpoint', PARAM_URL);
-        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? '');
+        $mform->setDefault('endpoint', $this->actionconfig['endpoint'] ?? $providerendpoint . '/chat/completions');
+
+
 
         // System Instructions.
         $mform->addElement(

--- a/plugins/ai/provider/openaicompatible/classes/hook_listener.php
+++ b/plugins/ai/provider/openaicompatible/classes/hook_listener.php
@@ -50,7 +50,6 @@ class hook_listener {
         );
         $mform->setType('apiendpoint', PARAM_URL);
         $mform->addHelpButton('apiendpoint', 'apiendpoint', 'aiprovider_openaicompatible');
-        $mform->setDefault('apiendpoint', 'https://api.openai.com/v1');
         $mform->addRule('apiendpoint', get_string('required'), 'required', null, 'client');
 
         // Model setting.
@@ -62,7 +61,6 @@ class hook_listener {
         );
         $mform->setType('model', PARAM_TEXT);
         $mform->addHelpButton('model', 'model', 'aiprovider_openaicompatible');
-        $mform->addRule('model', get_string('required'), 'required', null, 'client');
 
         // Required setting to store OpenAI API key.
         $mform->addElement(

--- a/plugins/ai/provider/openaicompatible/classes/hook_listener.php
+++ b/plugins/ai/provider/openaicompatible/classes/hook_listener.php
@@ -52,15 +52,7 @@ class hook_listener {
         $mform->addHelpButton('apiendpoint', 'apiendpoint', 'aiprovider_openaicompatible');
         $mform->addRule('apiendpoint', get_string('required'), 'required', null, 'client');
 
-        // Model setting.
-        $mform->addElement(
-            'text',
-            'model',
-            get_string('model', 'aiprovider_openaicompatible'),
-            ['size' => 30],
-        );
-        $mform->setType('model', PARAM_TEXT);
-        $mform->addHelpButton('model', 'model', 'aiprovider_openaicompatible');
+
 
         // Required setting to store OpenAI API key.
         $mform->addElement(

--- a/plugins/ai/provider/openaicompatible/classes/process_generate_image.php
+++ b/plugins/ai/provider/openaicompatible/classes/process_generate_image.php
@@ -33,19 +33,29 @@ class process_generate_image extends abstract_processor {
     /** @var int The number of images to generate dall-e-3 only supports 1. */
     private int $numberimages = 1;
 
-    /** @var string Response format: url or b64_json. */
-    private string $responseformat = 'url';
-
     #[\Override]
     protected function query_ai_api(): array {
         $response = parent::query_ai_api();
 
-        // If the request was successful, save the URL to a file.
+        // If the request was successful, save the URL or b64json to a file.
         if ($response['success']) {
-            $fileobj = $this->url_to_file(
-                $this->action->get_configuration('userid'),
-                $response['sourceurl']
-            );
+            if (!empty($response['b64json'])) {
+                $fileobj = $this->create_file_from_b64json(
+                    $this->action->get_configuration('userid'),
+                    $response
+                );
+            } else if (!empty($response['sourceurl'])) {
+                $fileobj = $this->url_to_file(
+                    $this->action->get_configuration('userid'),
+                    $response['sourceurl']
+                );
+            } else {
+                 return [
+                     'success' => false,
+                     'errorcode' => 500,
+                     'errormessage' => 'No image data returned from API.',
+                 ];
+            }
             // Add the file to the response, so the calling placement can do whatever they want with it.
             $response['draftfile'] = $fileobj;
         }
@@ -54,23 +64,59 @@ class process_generate_image extends abstract_processor {
     }
 
     /**
-     * Convert the given aspect ratio to an image size
-     * that is compatible with the OpenAI API.
+     * Convert the given aspect ratio to an image size compatible with the OpenAI API.
      *
-     * @param string $ratio The aspect ratio of the image.
-     * @return string The size of the image.
+     * Delegates to the model class if one is found for the configured model,
+     * otherwise falls back to a default mapping: 'square' → '1024x1024',
+     * 'landscape' → '1536x1024', 'portrait' → '1024x1536'.
+     *
+     * @param string $ratio The aspect ratio of the image ('square', 'landscape', or 'portrait').
+     * @return string The size string to send in the API request (e.g. '1024x1024').
      */
     private function calculate_size(string $ratio): string {
+        // Get model class.
+        $modelclass = helper::get_model_class($this->get_model());
+        if ($modelclass && method_exists($modelclass, 'calculate_size')) {
+            return $modelclass->calculate_size($ratio);
+        }
+        // Fallback.
         if ($ratio === 'square') {
             $size = '1024x1024';
         } else if ($ratio === 'landscape') {
-            $size = '1792x1024';
+            $size = '1536x1024';
         } else if ($ratio === 'portrait') {
-            $size = '1024x1792';
+            $size = '1024x1536';
         } else {
             throw new \coding_exception('Invalid aspect ratio: ' . $ratio);
         }
         return $size;
+    }
+
+    /**
+     * Convert the given quality setting to an API-compatible quality value.
+     *
+     * Delegates to the model class if one is found for the configured model,
+     * otherwise falls back to a default mapping: 'standard' → 'medium', 'hd' → 'high'.
+     *
+     * @param string $quality The quality setting from the action ('standard' or 'hd').
+     * @return string The quality value to send in the API request.
+     */
+    private function calculate_quality(string $quality): string {
+        // Get model class.
+        $modelclass = helper::get_model_class($this->get_model());
+        if ($modelclass && method_exists($modelclass, 'calculate_quality')) {
+            return $modelclass->calculate_quality($quality);
+        }
+        // Fallback.
+        if ($quality === 'standard') {
+            $processedquality = 'medium';
+        } else if ($quality === 'hd') {
+            $processedquality = 'high';
+        } else {
+            throw new \coding_exception('Invalid quality: ' . $quality);
+        }
+
+        return $processedquality;
     }
 
     #[\Override]
@@ -81,10 +127,33 @@ class process_generate_image extends abstract_processor {
         $requestobj->user = $userid;
         $requestobj->prompt = $this->action->get_configuration('prompttext');
         $requestobj->n = $this->numberimages;
-        $requestobj->quality = $this->action->get_configuration('quality');
-        $requestobj->response_format = $this->responseformat;
+        
+        $requestobj->quality = $this->calculate_quality($this->action->get_configuration('quality'));
         $requestobj->size = $this->calculate_size($this->action->get_configuration('aspectratio'));
-        $requestobj->style = $this->action->get_configuration('style');
+
+        // Get model class.
+        $modelclass = helper::get_model_class($this->get_model());
+        if ($modelclass instanceof \aiprovider_openaicompatible\aimodel\openai_image_base) {
+            $responseformat = $modelclass->response_format();
+            if ($responseformat !== null) {
+                $requestobj->response_format = $responseformat;
+            }
+            $outputformat = $modelclass->get_output_format();
+            if ($outputformat !== null) {
+                $requestobj->output_format = $outputformat;
+            }
+        } else {
+            // For unknown models, add the style if provided.
+            // Newer models (dall-e-3, gpt-image) do not support style.
+            $style = $this->action->get_configuration('style');
+            if ($style) {
+                $requestobj->style = $style;
+            }
+            // Request b64_json to avoid needing additional HTTP requests for download, if supported.
+            // Some old or custom endpoints might only support 'url', so we handle both in handle_api_success.
+            $requestobj->response_format = 'b64_json';
+        }
+
         // Append the extra model settings.
         $modelsettings = $this->get_model_settings();
         foreach ($modelsettings as $setting => $value) {
@@ -103,13 +172,63 @@ class process_generate_image extends abstract_processor {
         $responsebody = $response->getBody();
         $bodyobj = json_decode($responsebody->getContents());
 
+        $b64json = $bodyobj->data[0]->b64_json ?? null;
+        $url = $bodyobj->data[0]->url ?? null;
+
         return [
             'success' => true,
-            'sourceurl' => $bodyobj->data[0]->url,
-            'revisedprompt' => $bodyobj->data[0]->revised_prompt,
+            'b64json' => $b64json,
+            'sourceurl' => $url,
+            'output_format' => $bodyobj->output_format ?? 'png',
+            'revisedprompt' => $bodyobj->data[0]->revised_prompt ?? '',
             'model' => $this->get_model(), // There is no model in the response, use config.
             'errormessage' => '',
         ];
+    }
+
+    /**
+     * Decode the base64-encoded image from the API response, add a watermark,
+     * and store it as a draft file for the given user.
+     *
+     * Placements can't interact with the provider AI directly,
+     * therefore we need to provide the image file in a format that can
+     * be used by placements. So we use the file API.
+     *
+     * @param int $userid The user id.
+     * @param array $response Response from the AI provider, containing 'b64json' and 'output_format'.
+     * @return \stored_file The stored draft file.
+     */
+    private function create_file_from_b64json(
+        int $userid,
+        array $response,
+    ): \stored_file {
+        global $CFG;
+
+        require_once("{$CFG->libdir}/filelib.php");
+
+        // Decode the image and store in temp dir.
+        $b64json = $response['b64json'];
+        $imagebytes = base64_decode($b64json);
+        $filename = substr(hash('sha512', $b64json), 0, 16) . '.' . $response['output_format'];
+        $tempdst = make_request_directory() . DIRECTORY_SEPARATOR . $filename;
+        file_put_contents($tempdst, $imagebytes);
+
+        // Add the watermark.
+        $image = new ai_image($tempdst);
+        $image->add_watermark()->save();
+
+        // We put the file in the user draft area initially.
+        // Placements (on behalf of the user) can then move it to the correct location.
+        $fileinfo = new \stdClass();
+        $fileinfo->contextid = \context_user::instance($userid)->id;
+        $fileinfo->filearea = 'draft';
+        $fileinfo->component = 'user';
+        $fileinfo->itemid = file_get_unused_draft_itemid();
+        $fileinfo->filepath = '/';
+        $fileinfo->filename = $filename;
+
+        $fs = get_file_storage();
+        return $fs->create_file_from_string($fileinfo, file_get_contents($tempdst));
     }
 
     /**

--- a/plugins/ai/provider/openaicompatible/classes/process_generate_image.php
+++ b/plugins/ai/provider/openaicompatible/classes/process_generate_image.php
@@ -16,6 +16,7 @@
 
 namespace aiprovider_openaicompatible;
 
+use aiprovider_openaicompatible\aimodel\openai_image_base;
 use core\http_client;
 use core_ai\ai_image;
 use GuzzleHttp\Psr7\Request;
@@ -30,33 +31,20 @@ use Psr\Http\Message\ResponseInterface;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class process_generate_image extends abstract_processor {
-    /** @var int The number of images to generate dall-e-3 only supports 1. */
+    /** @var int The number of images to generate. */
     private int $numberimages = 1;
 
     #[\Override]
     protected function query_ai_api(): array {
         $response = parent::query_ai_api();
 
-        // If the request was successful, save the URL or b64json to a file.
+        // If the request was successful, save the image data to a Moodle draft file.
         if ($response['success']) {
-            if (!empty($response['b64json'])) {
-                $fileobj = $this->create_file_from_b64json(
-                    $this->action->get_configuration('userid'),
-                    $response
-                );
-            } else if (!empty($response['sourceurl'])) {
-                $fileobj = $this->url_to_file(
-                    $this->action->get_configuration('userid'),
-                    $response['sourceurl']
-                );
-            } else {
-                 return [
-                     'success' => false,
-                     'errorcode' => 500,
-                     'errormessage' => 'No image data returned from API.',
-                 ];
-            }
-            // Add the file to the response, so the calling placement can do whatever they want with it.
+            $fileobj = $this->create_file_from_response(
+                $this->action->get_configuration('userid'),
+                $response
+            );
+            // Add the file to the response so placements can use it.
             $response['draftfile'] = $fileobj;
         }
 
@@ -67,19 +55,17 @@ class process_generate_image extends abstract_processor {
      * Convert the given aspect ratio to an image size compatible with the OpenAI API.
      *
      * Delegates to the model class if one is found for the configured model,
-     * otherwise falls back to a default mapping: 'square' → '1024x1024',
-     * 'landscape' → '1536x1024', 'portrait' → '1024x1536'.
+     * otherwise falls back to a default mapping.
      *
-     * @param string $ratio The aspect ratio of the image ('square', 'landscape', or 'portrait').
-     * @return string The size string to send in the API request (e.g. '1024x1024').
+     * @param string $ratio The aspect ratio ('square', 'landscape', or 'portrait').
+     * @return string The size string for the API request (e.g. '1024x1024').
      */
     private function calculate_size(string $ratio): string {
-        // Get model class.
         $modelclass = helper::get_model_class($this->get_model());
-        if ($modelclass && method_exists($modelclass, 'calculate_size')) {
+        if ($modelclass instanceof openai_image_base) {
             return $modelclass->calculate_size($ratio);
         }
-        // Fallback.
+        // Fallback for unknown/custom models.
         if ($ratio === 'square') {
             $size = '1024x1024';
         } else if ($ratio === 'landscape') {
@@ -96,18 +82,17 @@ class process_generate_image extends abstract_processor {
      * Convert the given quality setting to an API-compatible quality value.
      *
      * Delegates to the model class if one is found for the configured model,
-     * otherwise falls back to a default mapping: 'standard' → 'medium', 'hd' → 'high'.
+     * otherwise falls back to a default mapping.
      *
      * @param string $quality The quality setting from the action ('standard' or 'hd').
-     * @return string The quality value to send in the API request.
+     * @return string The quality value for the API request.
      */
     private function calculate_quality(string $quality): string {
-        // Get model class.
         $modelclass = helper::get_model_class($this->get_model());
-        if ($modelclass && method_exists($modelclass, 'calculate_quality')) {
+        if ($modelclass instanceof openai_image_base) {
             return $modelclass->calculate_quality($quality);
         }
-        // Fallback.
+        // Fallback for unknown/custom models.
         if ($quality === 'standard') {
             $processedquality = 'medium';
         } else if ($quality === 'hd') {
@@ -115,7 +100,6 @@ class process_generate_image extends abstract_processor {
         } else {
             throw new \coding_exception('Invalid quality: ' . $quality);
         }
-
         return $processedquality;
     }
 
@@ -127,13 +111,12 @@ class process_generate_image extends abstract_processor {
         $requestobj->user = $userid;
         $requestobj->prompt = $this->action->get_configuration('prompttext');
         $requestobj->n = $this->numberimages;
-        
         $requestobj->quality = $this->calculate_quality($this->action->get_configuration('quality'));
         $requestobj->size = $this->calculate_size($this->action->get_configuration('aspectratio'));
 
-        // Get model class.
+        // Apply model-specific parameters (response_format and output_format).
         $modelclass = helper::get_model_class($this->get_model());
-        if ($modelclass instanceof \aiprovider_openaicompatible\aimodel\openai_image_base) {
+        if ($modelclass instanceof openai_image_base) {
             $responseformat = $modelclass->response_format();
             if ($responseformat !== null) {
                 $requestobj->response_format = $responseformat;
@@ -142,26 +125,17 @@ class process_generate_image extends abstract_processor {
             if ($outputformat !== null) {
                 $requestobj->output_format = $outputformat;
             }
-        } else {
-            // For unknown models, add the style if provided.
-            // Newer models (dall-e-3, gpt-image) do not support style.
-            $style = $this->action->get_configuration('style');
-            if ($style) {
-                $requestobj->style = $style;
-            }
-            // Request b64_json to avoid needing additional HTTP requests for download, if supported.
-            // Some old or custom endpoints might only support 'url', so we handle both in handle_api_success.
-            $requestobj->response_format = 'b64_json';
         }
 
-        // Append the extra model settings.
+        // Append any extra model settings from admin config.
         $modelsettings = $this->get_model_settings();
         foreach ($modelsettings as $setting => $value) {
             $requestobj->$setting = $value;
         }
+
         return new Request(
             'POST',
-            'images/generations',
+            '',
             ['Content-Type' => 'application/json'],
             json_encode($requestobj)
         );
@@ -172,33 +146,29 @@ class process_generate_image extends abstract_processor {
         $responsebody = $response->getBody();
         $bodyobj = json_decode($responsebody->getContents());
 
-        $b64json = $bodyobj->data[0]->b64_json ?? null;
-        $url = $bodyobj->data[0]->url ?? null;
-
         return [
             'success' => true,
-            'b64json' => $b64json,
-            'sourceurl' => $url,
+            'b64json' => $bodyobj->data[0]->b64_json ?? null,
+            'sourceurl' => $bodyobj->data[0]->url ?? null,
             'output_format' => $bodyobj->output_format ?? 'png',
             'revisedprompt' => $bodyobj->data[0]->revised_prompt ?? '',
-            'model' => $this->get_model(), // There is no model in the response, use config.
+            'model' => $this->get_model(),
             'errormessage' => '',
         ];
     }
 
     /**
-     * Decode the base64-encoded image from the API response, add a watermark,
-     * and store it as a draft file for the given user.
+     * Convert image data from the API response into a Moodle draft file.
      *
-     * Placements can't interact with the provider AI directly,
-     * therefore we need to provide the image file in a format that can
-     * be used by placements. So we use the file API.
+     * Handles both inline base64 (b64_json) and remote URL responses.
+     * Placements can't interact with the provider AI directly, so the image
+     * must be stored via the Moodle File API in the user's draft area.
      *
      * @param int $userid The user id.
-     * @param array $response Response from the AI provider, containing 'b64json' and 'output_format'.
+     * @param array $response Response from the AI provider.
      * @return \stored_file The stored draft file.
      */
-    private function create_file_from_b64json(
+    private function create_file_from_response(
         int $userid,
         array $response,
     ): \stored_file {
@@ -206,64 +176,34 @@ class process_generate_image extends abstract_processor {
 
         require_once("{$CFG->libdir}/filelib.php");
 
-        // Decode the image and store in temp dir.
-        $b64json = $response['b64json'];
-        $imagebytes = base64_decode($b64json);
-        $filename = substr(hash('sha512', $b64json), 0, 16) . '.' . $response['output_format'];
-        $tempdst = make_request_directory() . DIRECTORY_SEPARATOR . $filename;
-        file_put_contents($tempdst, $imagebytes);
+        if (!empty($response['b64json'])) {
+            // Preferred path: inline base64, no secondary HTTP call needed.
+            $b64json = $response['b64json'];
+            $imagebytes = base64_decode($b64json);
+            $outputformat = $response['output_format'] ?? 'png';
+            $filename = substr(hash('sha512', $b64json), 0, 16) . '.' . $outputformat;
+            $tempdst = make_request_directory() . DIRECTORY_SEPARATOR . $filename;
+            file_put_contents($tempdst, $imagebytes);
+        } else if (!empty($response['sourceurl'])) {
+            // Fallback: download from remote URL.
+            $url = $response['sourceurl'];
+            $parsedurl = parse_url($url, PHP_URL_PATH);
+            $filename = basename($parsedurl);
+            $tempdst = make_request_directory() . DIRECTORY_SEPARATOR . $filename;
+            $client = \core\di::get(http_client::class);
+            $client->get($url, [
+                'sink' => $tempdst,
+                'timeout' => $CFG->repositorygetfiletimeout,
+            ]);
+        } else {
+            throw new \moodle_exception('No image data returned from the AI API.');
+        }
 
-        // Add the watermark.
+        // Add the AI watermark.
         $image = new ai_image($tempdst);
         $image->add_watermark()->save();
 
-        // We put the file in the user draft area initially.
-        // Placements (on behalf of the user) can then move it to the correct location.
-        $fileinfo = new \stdClass();
-        $fileinfo->contextid = \context_user::instance($userid)->id;
-        $fileinfo->filearea = 'draft';
-        $fileinfo->component = 'user';
-        $fileinfo->itemid = file_get_unused_draft_itemid();
-        $fileinfo->filepath = '/';
-        $fileinfo->filename = $filename;
-
-        $fs = get_file_storage();
-        return $fs->create_file_from_string($fileinfo, file_get_contents($tempdst));
-    }
-
-    /**
-     * Convert the url for the image to a file.
-     *
-     * Placements can't interact with the provider AI directly,
-     * therefore we need to provide the image file in a format that can
-     * be used by placements. So we use the file API.
-     *
-     * @param int $userid The user id.
-     * @param string $url The URL to the image.
-     * @return \stored_file The file object.
-     */
-    private function url_to_file(int $userid, string $url): \stored_file {
-        global $CFG;
-
-        require_once("{$CFG->libdir}/filelib.php");
-
-        $parsedurl = parse_url($url, PHP_URL_PATH); // Parse the URL to get the path.
-        $filename = basename($parsedurl); // Get the basename of the path.
-
-        $client = \core\di::get(http_client::class);
-
-        // Download the image and add the watermark.
-        $tempdst = make_request_directory() . DIRECTORY_SEPARATOR . $filename;
-        $client->get($url, [
-            'sink' => $tempdst,
-            'timeout' => $CFG->repositorygetfiletimeout,
-        ]);
-
-        $image = new ai_image($tempdst);
-        $image->add_watermark()->save();
-
-        // We put the file in the user draft area initially.
-        // Placements (on behalf of the user) can then move it to the correct location.
+        // Store in the user's draft file area.
         $fileinfo = new \stdClass();
         $fileinfo->contextid = \context_user::instance($userid)->id;
         $fileinfo->filearea = 'draft';

--- a/plugins/ai/provider/openaicompatible/classes/process_generate_text.php
+++ b/plugins/ai/provider/openaicompatible/classes/process_generate_text.php
@@ -65,7 +65,7 @@ class process_generate_text extends abstract_processor {
 
         return new Request(
             'POST',
-            'chat/completions',
+            '',
             ['Content-Type' => 'application/json'],
             json_encode($requestobj)
         );

--- a/plugins/ai/provider/openaicompatible/classes/process_generate_text.php
+++ b/plugins/ai/provider/openaicompatible/classes/process_generate_text.php
@@ -83,12 +83,12 @@ class process_generate_text extends abstract_processor {
 
         return [
             'success' => true,
-            'id' => $bodyobj->id,
-            'fingerprint' => $bodyobj->system_fingerprint,
-            'generatedcontent' => $bodyobj->choices[0]->message->content,
-            'finishreason' => $bodyobj->choices[0]->finish_reason,
-            'prompttokens' => $bodyobj->usage->prompt_tokens,
-            'completiontokens' => $bodyobj->usage->completion_tokens,
+            'id' => $bodyobj->id ?? '',
+            'fingerprint' => $bodyobj->system_fingerprint ?? '',
+            'generatedcontent' => $bodyobj->choices[0]->message->content ?? '',
+            'finishreason' => $bodyobj->choices[0]->finish_reason ?? '',
+            'prompttokens' => $bodyobj->usage->prompt_tokens ?? 0,
+            'completiontokens' => $bodyobj->usage->completion_tokens ?? 0,
             'model' => $bodyobj->model ?? $this->get_model(), // Fallback to config model.
             'errormessage' => '',
         ];

--- a/plugins/ai/provider/openaicompatible/classes/provider.php
+++ b/plugins/ai/provider/openaicompatible/classes/provider.php
@@ -106,12 +106,5 @@ class provider extends \core_ai\provider {
         return $this->config['apiendpoint'] ?? null;
     }
 
-    /**
-     * Get the model from the provider configuration.
-     *
-     * @return string|null The model or null if not set.
-     */
-    public function get_api_model(): ?string {
-        return $this->config['model'] ?? null;
-    }
+
 }

--- a/plugins/ai/provider/openaicompatible/lang/en/aiprovider_openaicompatible.php
+++ b/plugins/ai/provider/openaicompatible/lang/en/aiprovider_openaicompatible.php
@@ -46,7 +46,7 @@ $string['apikey'] = 'OpenAI API key';
 $string['model'] = 'Model Name';
 $string['model_help'] = 'The ID of the model to use (e.g., gpt-4, claude-3-opus, llama-3).';
 $string['apikey_help'] = 'Get a key from your <a href="https://platform.openai.com/account/api-keys" target="_blank">OpenAI API keys</a>.';
-$string['custom_model_name'] = 'Custom model name';
+$string['custom_model_name'] = 'Model';
 $string['extraparams'] = 'Extra parameters';
 $string['extraparams_help'] = 'Extra parameters can be configured here. We support JSON format. For example:
 <pre>

--- a/plugins/ai/provider/openaicompatible/lang/en/aiprovider_openaicompatible.php
+++ b/plugins/ai/provider/openaicompatible/lang/en/aiprovider_openaicompatible.php
@@ -42,10 +42,10 @@ $string['action:summarise_text:systeminstruction'] = 'System instruction';
 $string['action:summarise_text:systeminstruction_help'] = 'This instruction is sent to the AI model along with the user\'s prompt. Editing this instruction is not recommended unless absolutely required.';
 $string['apiendpoint'] = 'API Endpoint';
 $string['apiendpoint_help'] = 'The base URL for your OpenAI-compatible API (e.g., https://api.openai.com/v1 or https://ai.kivoyo.com/api/v1).';
-$string['apikey'] = 'OpenAI API key';
+$string['apikey'] = 'OpenAI compatible API key';
 $string['model'] = 'Model Name';
 $string['model_help'] = 'The ID of the model to use (e.g., gpt-4, claude-3-opus, llama-3).';
-$string['apikey_help'] = 'Get a key from your <a href="https://platform.openai.com/account/api-keys" target="_blank">OpenAI API keys</a>.';
+$string['apikey_help'] = 'The API key used to authenticate requests to your OpenAI-compatible API endpoint.';
 $string['custom_model_name'] = 'Model';
 $string['extraparams'] = 'Extra parameters';
 $string['extraparams_help'] = 'Extra parameters can be configured here. We support JSON format. For example:
@@ -56,8 +56,8 @@ $string['extraparams_help'] = 'Extra parameters can be configured here. We suppo
 }
 </pre>';
 $string['invalidjson'] = 'Invalid JSON string';
-$string['orgid'] = 'OpenAI organization ID';
-$string['orgid_help'] = 'Get your OpenAI organization ID from your <a href="https://platform.openai.com/account/org-settings" target="_blank">OpenAI account</a>.';
+$string['orgid'] = 'OpenAI compatible organization ID';
+$string['orgid_help'] = 'The organization ID used to authenticate requests to your OpenAI-compatible API endpoint. Leave blank if not required by your provider.';
 $string['pluginname'] = 'OpenAI Compatible API provider';
 $string['privacy:metadata'] = 'The OpenAI API provider plugin does not store any personal data.';
 $string['privacy:metadata:aiprovider_openaicompatible:externalpurpose'] = 'This information is sent to the OpenAI API in order for a response to be generated. Your OpenAI account settings may change how OpenAI stores and retains this data. No user data is explicitly sent to OpenAI or stored in Moodle LMS by this plugin.';

--- a/plugins/ai/provider/openaicompatible/tests/fixtures/image_request_success.json
+++ b/plugins/ai/provider/openaicompatible/tests/fixtures/image_request_success.json
@@ -2,8 +2,8 @@
   "created": 1719140500,
   "data": [
     {
-      "revised_prompt": "An image that represents the concept of a 'test'. It could be a variety of things, such as a piece of paper with multiple-choice questions, a scientist in a lab conducting experiments, or a student at a desk studying for an upcoming exam. This image should use vivid colors and clear, detailed imagery to clearly represent the concept of 'test'.",
-      "url": "https:\/\/oaidalleapiprodscus.blob.core.windows.net\/private\/org-EdXlYn9JmBUAo1tZ1QeRcOvg\/user-8GYNL27bMyzS3WcLtkUwREgd\/img-uPMRNi0R9lxPPJYOf4NZUmMY.png?st=2024-06-23T10%3A01%3A40Z&se=2024-06-23T12%3A01%3A40Z&sp=r&sv=2023-11-03&sr=b&rscd=inline&rsct=image\/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-06-23T00%3A13%3A04Z&ske=2024-06-24T00%3A13%3A04Z&sks=b&skv=2023-11-03&sig=bmZqUqQ2QLrmQFSGxTRQoKRVf4C6VyYCZ0aA4Y5%2BGCs%3D"
+      "revised_prompt": "An image that represents the concept of a 'test'.",
+      "b64_json": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     }
   ]
 }

--- a/plugins/ai/provider/openaicompatible/tests/process_generate_image_test.php
+++ b/plugins/ai/provider/openaicompatible/tests/process_generate_image_test.php
@@ -59,7 +59,7 @@ final class process_generate_image_test extends \advanced_testcase {
         $this->provider = $this->create_provider(
             actionclass: \core_ai\aiactions\generate_image::class,
             actionconfig: [
-                'model' => 'dall-e-3',
+                'model' => 'gpt-image-1',
             ],
         );
         $this->create_action();
@@ -82,7 +82,7 @@ final class process_generate_image_test extends \advanced_testcase {
     }
 
     /**
-     * Test calculate_size.
+     * Test calculate_size with gpt-image-1 size mappings.
      */
     public function test_calculate_size(): void {
         $processor = new process_generate_image($this->provider, $this->action);
@@ -96,15 +96,16 @@ final class process_generate_image_test extends \advanced_testcase {
 
         $ratio = 'portrait';
         $size = $method->invoke($processor, $ratio);
-        $this->assertEquals('1024x1792', $size);
+        $this->assertEquals('1024x1536', $size);
 
         $ratio = 'landscape';
         $size = $method->invoke($processor, $ratio);
-        $this->assertEquals('1792x1024', $size);
+        $this->assertEquals('1536x1024', $size);
     }
 
     /**
-     * Test create_request_object
+     * Test create_request_object with gpt-image-1.
+     * gpt-image-1: no response_format param, quality 'hd' maps to 'high'.
      */
     public function test_create_request_object(): void {
         $processor = new process_generate_image($this->provider, $this->action);
@@ -116,10 +117,12 @@ final class process_generate_image_test extends \advanced_testcase {
         $requestdata = (object) json_decode($request->getBody()->getContents());
 
         $this->assertEquals('This is a test prompt', $requestdata->prompt);
-        $this->assertEquals('dall-e-3', $requestdata->model);
+        $this->assertEquals('gpt-image-1', $requestdata->model);
         $this->assertEquals('1', $requestdata->n);
-        $this->assertEquals('hd', $requestdata->quality);
-        $this->assertEquals('url', $requestdata->response_format);
+        // gpt-image-1 maps 'hd' quality to 'high'.
+        $this->assertEquals('high', $requestdata->quality);
+        // gpt-image-1 does not send response_format.
+        $this->assertObjectNotHasProperty('response_format', $requestdata);
         $this->assertEquals('1024x1024', $requestdata->size);
     }
 
@@ -130,7 +133,7 @@ final class process_generate_image_test extends \advanced_testcase {
         $this->provider = $this->create_provider(
             actionclass: \core_ai\aiactions\generate_image::class,
             actionconfig: [
-                'model' => 'dall-e-3',
+                'model' => 'gpt-image-1',
                 'temperature' => '0.5',
                 'max_completion_tokens' => '100',
             ],
@@ -143,7 +146,7 @@ final class process_generate_image_test extends \advanced_testcase {
 
         $body = (object) json_decode($request->getBody()->getContents());
 
-        $this->assertEquals('dall-e-3', $body->model);
+        $this->assertEquals('gpt-image-1', $body->model);
         $this->assertEquals('0.5', $body->temperature);
         $this->assertEquals('100', $body->max_completion_tokens);
 
@@ -200,6 +203,7 @@ final class process_generate_image_test extends \advanced_testcase {
 
     /**
      * Test the API success response handler method.
+     * Fixture now returns b64_json (gpt-image-1 style response).
      */
     public function test_handle_api_success(): void {
         $response = new Response(
@@ -214,32 +218,25 @@ final class process_generate_image_test extends \advanced_testcase {
 
         $result = $method->invoke($processor, $response);
 
-        $this->stringContains('An image that represents the concept of a \'test\'.', $result['revisedprompt']);
-        $this->stringContains('oaidalleapiprodscus.blob.core.windows.net', $result['sourceurl']);
-        $this->assertEquals('dall-e-3', $result['model']);
+        $this->assertTrue($result['success']);
+        $this->assertNotEmpty($result['b64json']);
+        $this->assertStringContainsString("concept of a 'test'.", $result['revisedprompt']);
+        $this->assertEquals('gpt-image-1', $result['model']);
     }
 
     /**
-     * Test query_ai_api for a successful call.
+     * Test query_ai_api for a successful call with b64_json response.
+     * gpt-image-1 returns b64_json inline — no secondary download needed.
      */
     public function test_query_ai_api_success(): void {
         // Mock the http client to return a successful response.
         ['mock' => $mock] = $this->get_mocked_http_client();
 
-        // The response from OpenAI.
+        // The response from the API (b64_json inline).
         $mock->append(new Response(
             200,
             ['Content-Type' => 'application/json'],
             $this->responsebodyjson,
-        ));
-
-        $mock->append(new Response(
-            200,
-            ['Content-Type' => 'image/jpeg'],
-            \GuzzleHttp\Psr7\Utils::streamFor(fopen(
-                self::get_fixture_path('aiprovider_openaicompatible', 'test.jpg'),
-                'r',
-            )),
         ));
 
         $this->setAdminUser();
@@ -248,9 +245,10 @@ final class process_generate_image_test extends \advanced_testcase {
         $method = new \ReflectionMethod($processor, 'query_ai_api');
         $result = $method->invoke($processor);
 
-        $this->stringContains('An image that represents the concept of a \'test\'.', $result['revisedprompt']);
-        $this->stringContains('oaidalleapiprodscus.blob.core.windows.net', $result['sourceurl']);
-        $this->assertEquals('dall-e-3', $result['model']);
+        $this->assertTrue($result['success']);
+        $this->assertNotEmpty($result['b64json']);
+        $this->assertStringContainsString("concept of a 'test'.", $result['revisedprompt']);
+        $this->assertEquals('gpt-image-1', $result['model']);
     }
 
     /**
@@ -264,9 +262,9 @@ final class process_generate_image_test extends \advanced_testcase {
 
         $response = [
             'success' => true,
-            'revisedprompt' => 'An image that represents the concept of a \'test\'.',
-            'imageurl' => 'oaidalleapiprodscus.blob.core.windows.net',
-            'model' => 'dall-e-3',
+            'revisedprompt' => "An image that represents the concept of a 'test'.",
+            'imageurl' => 'https://example.com/image.png',
+            'model' => 'gpt-image-1',
         ];
 
         $result = $method->invoke($processor, $response);
@@ -305,25 +303,7 @@ final class process_generate_image_test extends \advanced_testcase {
     }
 
     /**
-     * Test url_to_file.
-     */
-    public function test_url_to_file(): void {
-        // Log in user.
-        $this->setUser($this->getDataGenerator()->create_user());
-
-        $processor = new process_generate_image($this->provider, $this->action);
-        // We're working with a private method here, so we need to use reflection.
-        $method = new \ReflectionMethod($processor, 'url_to_file');
-
-        $contextid = 1;
-        $url = $this->getExternalTestFileUrl('/test.jpg', false);
-        $filenobj = $method->invoke($processor, $contextid, $url);
-
-        $this->assertEquals('test.jpg', $filenobj->get_filename());
-    }
-
-    /**
-     * Test process.
+     * Test process with a URL-based response (sourceurl fallback path).
      */
     public function test_process(): void {
         // Log in user.
@@ -334,7 +314,7 @@ final class process_generate_image_test extends \advanced_testcase {
 
         $url = 'https://example.com/test.jpg';
 
-        // The response from OpenAI.
+        // The response from the API (URL-based, tests the sourceurl fallback).
         $mock->append(new Response(
             200,
             ['Content-Type' => 'application/json'],
@@ -342,7 +322,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -380,7 +360,7 @@ final class process_generate_image_test extends \advanced_testcase {
         $this->assertInstanceOf(\core_ai\aiactions\responses\response_base::class, $result);
         $this->assertTrue($result->get_success());
         $this->assertEquals('generate_image', $result->get_actionname());
-        $this->assertEquals('An image that represents the concept of a \'test\'.', $result->get_response_data()['revisedprompt']);
+        $this->assertStringContainsString("concept of a 'test'.", $result->get_response_data()['revisedprompt']);
         $this->assertEquals($url, $result->get_response_data()['sourceurl']);
     }
 
@@ -436,8 +416,8 @@ final class process_generate_image_test extends \advanced_testcase {
             actionconfig: [
                 \core_ai\aiactions\generate_image::class => [
                     'settings' => [
-                        'model' => 'dall-e-3',
-                        'endpoint' => "https://api.openai.com/v1/chat/completions",
+                        'model' => 'gpt-image-1',
+                        'endpoint' => "https://api.openai.com/v1/images/generations",
                     ],
                 ],
             ],
@@ -457,7 +437,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -483,7 +463,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -517,7 +497,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -545,7 +525,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -588,8 +568,8 @@ final class process_generate_image_test extends \advanced_testcase {
             actionconfig: [
                 \core_ai\aiactions\generate_image::class => [
                     'settings' => [
-                        'model' => 'dall-e-3',
-                        'endpoint' => "https://api.openai.com/v1/chat/completions",
+                        'model' => 'gpt-image-1',
+                        'endpoint' => "https://api.openai.com/v1/images/generations",
                     ],
                 ],
             ],
@@ -609,7 +589,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -635,7 +615,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -671,7 +651,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],
@@ -699,7 +679,7 @@ final class process_generate_image_test extends \advanced_testcase {
                 'created' => 1719140500,
                 'data' => [
                     (object) [
-                        'revised_prompt' => 'An image that represents the concept of a \'test\'.',
+                        'revised_prompt' => "An image that represents the concept of a 'test'.",
                         'url' => $url,
                     ],
                 ],

--- a/plugins/ai/provider/openaicompatible/version.php
+++ b/plugins/ai/provider/openaicompatible/version.php
@@ -25,6 +25,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'aiprovider_openaicompatible';
-$plugin->version = 2025121000;
+$plugin->version = 2026060200;
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
# Description
This PR resolves two major configuration and API compatibility issues within the `aiprovider_openaicompatible` plugin to align it with upstream Moodle AI provider expectations.
### 1. Fixed Configuration Precedence
Previously, the plugin incorrectly prioritized the provider-level `model` and `endpoint` fields, completely ignoring per-action configurations. 
* **Precedence Inversion**: Updated `abstract_processor::get_model()` and `get_endpoint()` so per-action configurations rightfully override the provider-level fallbacks.
* **Provider Flexibility**: Dropped the `required` rule on the provider-level model field in `hook_listener`, allowing admins to rely on per-action model definitions.
* **Form Defaults**: Removed hardcoded `gpt-4o`/`dall-e-3` and `api.openai.com` defaults from the action forms. The plugin now correctly defaults to `custom` when no model is saved.
### 2. Modernized Image Generation (Port of MDL-85352)
Image generation was failing against newer OpenAI-compatible endpoints because the request payload utilized deprecated parameters (`style`, `response_format=url`).
* **Model Interfaces**: Ported Moodle core's `MDL-85352` architecture, introducing the `openai_image_base` interface .
* **Dynamic Requests**: Updated `process_generate_image` to dynamically drive the request based on the configured model class, managing new `quality` and `size` mappings.
* **Base64 Processing**: Refactored the response handler to decode `b64_json` inline payloads directly to Moodle's file API, eliminating the need for secondary outbound HTTP download requests.

Fixes #129 